### PR TITLE
Improve testability of Organization components

### DIFF
--- a/lib/CreateOrganizationModal/CreateOrganizationModalContainer.js
+++ b/lib/CreateOrganizationModal/CreateOrganizationModalContainer.js
@@ -63,12 +63,14 @@ export default class CreateOrganizationModal extends React.Component {
       >
         <TextField
           error={this.state.error}
+          id="create-org-modal-name-field"
           label={<FormattedMessage id="stripes-erm-components.createOrg.name" />}
           onChange={e => this.setState({ name: e.target.value })}
         />
         <Button
           buttonStyle="primary"
           disabled={!this.state.name}
+          id="create-org-modal-submit-btn"
           onClick={e => {
             e.preventDefault();
             this.createOrganization();

--- a/lib/OrganizationSelection/OrganizationSelectionContainer.js
+++ b/lib/OrganizationSelection/OrganizationSelectionContainer.js
@@ -23,6 +23,7 @@ export default class OrganizationSelectionContainer extends React.Component {
     meta: PropTypes.shape({
       error: PropTypes.node,
     }),
+    id: PropTypes.string,
     input: PropTypes.shape({
       onChange: PropTypes.func,
       value: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
@@ -90,6 +91,7 @@ export default class OrganizationSelectionContainer extends React.Component {
     return (
       <OrganizationSelectionDisplay
         error={get(this.props, ['meta', 'error'])}
+        id={this.props.id}
         loading={get(this.props.resources, ['organizations', 'isPending'], false)}
         onChange={this.handleChange}
         onFilter={this.handleFilter}

--- a/lib/OrganizationSelection/OrganizationSelectionDisplay.js
+++ b/lib/OrganizationSelection/OrganizationSelectionDisplay.js
@@ -12,6 +12,7 @@ export default class OrganizationSelectionDisplay extends React.Component {
   static propTypes = {
     error: PropTypes.node,
     loading: PropTypes.bool,
+    id: PropTypes.string,
     onChange: PropTypes.func,
     onFilter: PropTypes.func,
     organizations: PropTypes.arrayOf(
@@ -25,7 +26,7 @@ export default class OrganizationSelectionDisplay extends React.Component {
   };
 
   render() {
-    const { error, loading, onChange, onFilter, organizations, searchString, value } = this.props;
+    const { error, id, loading, onChange, onFilter, organizations, searchString, value } = this.props;
     return (
       <FormattedMessage id="stripes-erm-components.orgSelect.selectOrg">
         {placeholder => (
@@ -39,6 +40,7 @@ export default class OrganizationSelectionDisplay extends React.Component {
 
               return <OptionSegment {...props}>{option.label}</OptionSegment>;
             }}
+            id={id}
             onChange={onChange}
             onFilter={onFilter}
             placeholder={placeholder}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-erm-components",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Component library for Stripes ERM applications",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"


### PR DESCRIPTION
Changes focused on improving usage of components for automated testing:
- Create `id`s for `CreateOrganizationModal` elements.
- Pass `id`s through for `OrganizationSelection`
- Bump to v1.0.3 to allow users to target these changes.