### PR TITLE
Added LicenseCard component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 * Added `DocumentCard` component. Avail in 1.0.4.
 * Added `Spinner` component. Avail in 1.0.4.
 * Added `DocumentsFieldArray` component. Avail in 1.0.5.
+* Added `LicenseCard` component. Avail in 1.0.6.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 export { default as CreateOrganizationModal } from './lib/CreateOrganizationModal';
 export { default as DocumentCard } from './lib/DocumentCard';
 export { default as DocumentsFieldArray } from './lib/DocumentsFieldArray';
+export { default as LicenseCard } from './lib/LicenseCard';
 export { default as OrganizationSelection } from './lib/OrganizationSelection';
 export { default as Spinner } from './lib/Spinner';
 

--- a/lib/DocumentsFieldArray/DocumentsFieldArray.js
+++ b/lib/DocumentsFieldArray/DocumentsFieldArray.js
@@ -69,7 +69,7 @@ export default class DocumentsFieldArray extends React.Component {
     const { fields } = this.props;
 
     return docs.map((doc, i) => (
-      <div className={css.doc}>
+      <div className={css.doc} key={i}>
         <Row>
           <Col xs={11}>
             <Field

--- a/lib/LicenseCard/LicenseCard.js
+++ b/lib/LicenseCard/LicenseCard.js
@@ -1,0 +1,118 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { get } from 'lodash';
+import { FormattedDate, FormattedMessage } from 'react-intl';
+import { Col, KeyValue, Row } from '@folio/stripes/components';
+
+export default class LicenseCard extends React.Component {
+  static propTypes = {
+    className: PropTypes.string,
+    license: PropTypes.shape({
+      endDate: PropTypes.string,
+      openEnded: PropTypes.bool,
+      orgs: PropTypes.arrayOf(
+        PropTypes.shape({
+          org: PropTypes.shape({
+            name: PropTypes.string,
+          }),
+          role: PropTypes.shape({
+            value: PropTypes.string,
+          }),
+        }),
+      ),
+      startDate: PropTypes.string,
+      status: PropTypes.shape({
+        label: PropTypes.string,
+      }),
+      type: PropTypes.shape({
+        label: PropTypes.string,
+      }),
+    }),
+    renderName: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    license: {},
+    renderName: true,
+  }
+
+
+  renderEndDate() {
+    const { license } = this.props;
+    if (license.openEnded) return <FormattedMessage id="stripes-erm-components.licenseCard.openEnded" />;
+    if (license.endDate) return <FormattedDate value={license.endDate} />;
+
+    return '-';
+  }
+
+  renderLicensor = () => {
+    const { license: { orgs = [] } } = this.props;
+    const licensor = orgs.find(o => get(o, ['role', 'value']) === 'licensor');
+    const licensorName = get(licensor, ['org', 'name']) || <FormattedMessage id="stripes-erm-components.licenseCard.notSet" />;
+
+    return licensorName;
+  }
+
+  renderName = () => {
+    const { license, renderName } = this.props;
+
+    if (!renderName) return null;
+
+    return (
+      <Row>
+        <Col xs={12}>
+          <strong>
+            {license.name}
+          </strong>
+        </Col>
+      </Row>
+    );
+  }
+
+  render() {
+    const { license, className } = this.props;
+
+    return (
+      <div className={className}>
+        { this.renderName() }
+        <Row>
+          <Col xs={2}>
+            <KeyValue label={<FormattedMessage id="stripes-erm-components.licenseCard.type" />}>
+              <div data-test-license-card-type>
+                {get(license, ['type', 'label'], '-')}
+              </div>
+            </KeyValue>
+          </Col>
+          <Col xs={2}>
+            <KeyValue label={<FormattedMessage id="stripes-erm-components.licenseCard.status" />}>
+              <div data-test-license-card-status>
+                {get(license, ['status', 'label'], '-')}
+              </div>
+            </KeyValue>
+          </Col>
+          <Col xs={2}>
+            <KeyValue label={<FormattedMessage id="stripes-erm-components.licenseCard.startDate" />}>
+              <div data-test-license-card-start-date>
+                {license.startDate ? <FormattedDate value={license.startDate} /> : '-'}
+              </div>
+            </KeyValue>
+          </Col>
+          <Col xs={3}>
+            <KeyValue label={<FormattedMessage id="stripes-erm-components.licenseCard.endDate" />}>
+              <div data-test-license-card-end-date>
+                {this.renderEndDate()}
+              </div>
+            </KeyValue>
+          </Col>
+          <Col xs={3}>
+            <KeyValue label={<FormattedMessage id="stripes-erm-components.licenseCard.licensor" />}>
+              <div data-test-license-card-licensor-name>
+                {this.renderLicensor()}
+              </div>
+            </KeyValue>
+          </Col>
+        </Row>
+      </div>
+    );
+  }
+}

--- a/lib/LicenseCard/index.js
+++ b/lib/LicenseCard/index.js
@@ -1,0 +1,1 @@
+export { default } from './LicenseCard';

--- a/lib/LicenseCard/readme.md
+++ b/lib/LicenseCard/readme.md
@@ -1,0 +1,19 @@
+# LicenseCard
+
+Renders a card displaying information about licenses of the type [`License`](https://github.com/folio-org/mod-licenses/blob/master/service/grails-app/domain/org/olf/licenses/License.groovy) implemented by the `licenses` Okapi interface.
+
+
+## Basic Usage
+Simply passing a license object is all that's required.
+```
+return <LicenseCard license={license} />;
+```
+
+## Props
+
+| Name | Type | Description | Required | Default |
+--- | --- | --- | --- | --- |
+| `className` | string |
+| `license` | object | [`License`](https://github.com/folio-org/mod-licenses/blob/master/service/grails-app/domain/org/olf/licenses/License.groovy) | Yes |
+| `renderName` | bool | Set to `false` to turn off rendering the license name  | | `true` |
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-erm-components",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Component library for Stripes ERM applications",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"

--- a/translations/stripes-erm-components/en.json
+++ b/translations/stripes-erm-components/en.json
@@ -3,6 +3,14 @@
   "createOrg.createNew": "Create new organization",
   "createOrg.name": "Name",
 
+  "licenseCard.openEnded": "Open ended",
+  "licenseCard.notSet": "Not set",
+  "licenseCard.type": "Type",
+  "licenseCard.status": "Status",
+  "licenseCard.startDate": "Start date",
+  "licenseCard.endDate": "End date",
+  "licenseCard.licensor": "Licensor",
+
   "doc.addDoc": "Add  document",
   "doc.location": "Physical location",
   "doc.name": "Name",


### PR DESCRIPTION
# LicenseCard

Renders a card displaying information about licenses of the type [`License`](https://github.com/folio-org/mod-licenses/blob/master/service/grails-app/domain/org/olf/licenses/License.groovy) implemented by the `licenses` Okapi interface.


## Basic Usage
Simply passing a license object is all that's required.
```
import { LicenseCard } from '@folio/stripes-erm-components';
...
return <LicenseCard license={license} />;
```

## Props

| Name | Type | Description | Required | Default |
--- | --- | --- | --- | --- |
| `className` | string |
| `license` | object | [`License`](https://github.com/folio-org/mod-licenses/blob/master/service/grails-app/domain/org/olf/licenses/License.groovy) | Yes |
| `renderName` | bool | Set to `false` to turn off rendering the license name  | | `true` |
