### PR TITLE
Added LicenseEndDate component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 * Added `Spinner` component. Avail in 1.0.4.
 * Added `DocumentsFieldArray` component. Avail in 1.0.5.
 * Added `LicenseCard` component. Avail in 1.0.6.
+* Added `LicenseEndDate` component. Avail in 1.0.7.

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ export { default as CreateOrganizationModal } from './lib/CreateOrganizationModa
 export { default as DocumentCard } from './lib/DocumentCard';
 export { default as DocumentsFieldArray } from './lib/DocumentsFieldArray';
 export { default as LicenseCard } from './lib/LicenseCard';
+export { default as LicenseEndDate } from './lib/LicenseEndDate';
 export { default as OrganizationSelection } from './lib/OrganizationSelection';
 export { default as Spinner } from './lib/Spinner';
 

--- a/lib/DocumentCard/DocumentCard.js
+++ b/lib/DocumentCard/DocumentCard.js
@@ -74,7 +74,6 @@ export default class DocumentCard extends React.Component {
           }}
           interactive={false}
           visibleColumns={['type', 'reference']}
-
         />
       </Layout>
     );

--- a/lib/LicenseCard/LicenseCard.js
+++ b/lib/LicenseCard/LicenseCard.js
@@ -4,6 +4,8 @@ import { get } from 'lodash';
 import { FormattedDate, FormattedMessage } from 'react-intl';
 import { Col, KeyValue, Row } from '@folio/stripes/components';
 
+import LicenseEndDate from '../LicenseEndDate';
+
 export default class LicenseCard extends React.Component {
   static propTypes = {
     className: PropTypes.string,
@@ -34,15 +36,6 @@ export default class LicenseCard extends React.Component {
   static defaultProps = {
     license: {},
     renderName: true,
-  }
-
-
-  renderEndDate() {
-    const { license } = this.props;
-    if (license.openEnded) return <FormattedMessage id="stripes-erm-components.licenseCard.openEnded" />;
-    if (license.endDate) return <FormattedDate value={license.endDate} />;
-
-    return '-';
   }
 
   renderLicensor = () => {
@@ -100,7 +93,7 @@ export default class LicenseCard extends React.Component {
           <Col xs={3}>
             <KeyValue label={<FormattedMessage id="stripes-erm-components.licenseCard.endDate" />}>
               <div data-test-license-card-end-date>
-                {this.renderEndDate()}
+                <LicenseEndDate license={license} />
               </div>
             </KeyValue>
           </Col>

--- a/lib/LicenseEndDate/LicenseEndDate.js
+++ b/lib/LicenseEndDate/LicenseEndDate.js
@@ -1,0 +1,19 @@
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedDate, FormattedMessage } from 'react-intl';
+
+const LicenseEndDate = props => {
+  const { license: { endDate, openEnded } } = props;
+  if (openEnded) return <FormattedMessage id="stripes-erm-components.licenseCard.openEnded" />;
+  if (endDate) return <FormattedDate value={endDate} />;
+
+  return '-';
+};
+
+LicenseEndDate.propTypes = {
+  endDate: PropTypes.string,
+  openEnded: PropTypes.bool,
+};
+
+export default LicenseEndDate;

--- a/lib/LicenseEndDate/index.js
+++ b/lib/LicenseEndDate/index.js
@@ -1,0 +1,1 @@
+export { default } from './LicenseEndDate';

--- a/lib/LicenseEndDate/readme.md
+++ b/lib/LicenseEndDate/readme.md
@@ -1,0 +1,16 @@
+# LicenseEndDate
+
+Renders the effective end date of a license. This can differ due to fields such as `openEnded`.
+
+
+## Basic Usage
+Simply passing a license object is all that's required.
+```
+return <LicenseEndDate license={license} />;
+```
+
+## Props
+
+| Name | Type | Description | Required | Default |
+--- | --- | --- | --- | --- |
+| `license` | object | [`License`](https://github.com/folio-org/mod-licenses/blob/master/service/grails-app/domain/org/olf/licenses/License.groovy) | Yes |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-erm-components",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Component library for Stripes ERM applications",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"


### PR DESCRIPTION
# LicenseEndDate

Renders the effective end date of a license. This can differ due to fields such as `openEnded`.


## Basic Usage
Simply passing a license object is all that's required.
```
return <LicenseEndDate license={license} />;
```

## Props

| Name | Type | Description | Required | Default |
--- | --- | --- | --- | --- |
| `license` | object | [`License`](https://github.com/folio-org/mod-licenses/blob/master/service/grails-app/domain/org/olf/licenses/License.groovy) | Yes |
