### PR TITLE
Add support for qindex

### DIFF
--- a/lib/getSASParams.js
+++ b/lib/getSASParams.js
@@ -10,10 +10,10 @@ export default (options) => (queryParams, pathComponents, resources) => {
     stats: 'true',
   };
 
-  const { query: { query, filters, sort } } = resources;
+  const { query: { qindex, query, filters, sort } } = resources;
 
   if (query) {
-    params.match = searchKey;
+    params.match = qindex || searchKey;
     params.term = query;
   }
 


### PR DESCRIPTION
I need this so that when the user chooses to search in an index other than the default one specified as `searchKey` at compile-time, that selection can be overridden by the `qindex` portion of the URL query.