### PR TITLE
Support comma-separated multiple `match` parameters

### DIFF
--- a/lib/getSASParams.js
+++ b/lib/getSASParams.js
@@ -13,7 +13,7 @@ export default (options) => (queryParams, pathComponents, resources) => {
   const { query: { qindex, query, filters, sort } } = resources;
 
   if (query) {
-    params.match = qindex || searchKey;
+    params.match = (qindex || searchKey).split(',');
     params.term = query;
   }
 


### PR DESCRIPTION
This is that other small change I mentioned in Slack.

If the value that you pass at compile-time as `searchKey` or at run-time as `quindex` contains commas, then that compound value is split into multiple atomic values each of which gives rise to its own `match` parameter. So when at a URL containing `qindex=name,tags.value,symbols.symbol`, the generated back-end URL will include `?match=name&match=tags.value&match=symbols.symbol`.