### PR TITLE
Added withKiwtFieldArray HOC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.3.0 (IN PROGRESS)
 
 * Added `LicenseTermsList` component. Avail in 1.2.1.
+* Added `withKiwtFieldArray` higher-order component. Avail in 1.3.0.
 
 ## 1.2.0 (18-03-2019)
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+// Components
 export { default as CreateOrganizationModal } from './lib/CreateOrganizationModal';
 export { default as DocumentCard } from './lib/DocumentCard';
 export { default as DocumentsFieldArray } from './lib/DocumentsFieldArray';
@@ -7,4 +8,8 @@ export { default as LicenseTermsList } from './lib/LicenseTermsList';
 export { default as OrganizationSelection } from './lib/OrganizationSelection';
 export { default as Spinner } from './lib/Spinner';
 
+// HOCs
+export { default as withKiwtFieldArray } from './lib/withKiwtFieldArray/withKiwtFieldArray';
+
+// Functions, utilities, and misc.
 export { default as getSASParams } from './lib/getSASParams';

--- a/lib/DocumentsFieldArray/DocumentsFieldArray.js
+++ b/lib/DocumentsFieldArray/DocumentsFieldArray.js
@@ -14,13 +14,18 @@ import {
   IconButton,
 } from '@folio/stripes/components';
 
+import withKiwtFieldArray from '../withKiwtFieldArray';
+
 import css from './DocumentsFieldArray.css';
 
-export default class DocumentsFieldArray extends React.Component {
+class DocumentsFieldArray extends React.Component {
   static propTypes = {
     addDocBtnLabel: PropTypes.node,
-    fields: PropTypes.object,
     isEmptyMessage: PropTypes.node,
+    items: PropTypes.arrayOf(PropTypes.object),
+    name: PropTypes.string.isRequired,
+    onAddField: PropTypes.func.isRequired,
+    onDeleteField: PropTypes.func.isRequired,
   }
 
   static defaultProps = {
@@ -28,19 +33,9 @@ export default class DocumentsFieldArray extends React.Component {
     isEmptyMessage: <FormattedMessage id="stripes-erm-components.doc.noDocs" />,
   }
 
-  handleDeleteDoc = (index, doc) => {
-    const { fields } = this.props;
-
-    fields.remove(index);
-
-    if (doc.id) {
-      fields.push({ id: doc.id, _delete: true });
-    }
-  }
-
   validateDocIsSpecified = (value, allValues, props, name) => {
     const index = parseInt(/\[([0-9]*)\]/.exec(name)[1], 10);
-    const { location, url } = get(allValues, [this.props.fields.name, index], {});
+    const { location, url } = get(allValues, [this.props.name, index], {});
     if (!location && !url) {
       return <FormattedMessage id="stripes-erm-components.doc.error.docsMustHaveLocationOrURL" />;
     }
@@ -65,18 +60,18 @@ export default class DocumentsFieldArray extends React.Component {
     !value ? <FormattedMessage id="stripes-core.label.missingRequiredField" /> : undefined
   )
 
-  renderDocs = (docs) => {
-    const { fields } = this.props;
+  renderDocs = () => {
+    const { items, name, onDeleteField } = this.props;
 
-    return docs.map((doc, i) => (
+    return items.map((doc, i) => (
       <div className={css.doc} key={i}>
         <Row>
           <Col xs={11}>
             <Field
               component={TextField}
-              id={`${fields.name}-name-${i}`}
+              id={`${name}-name-${i}`}
               label={<FormattedMessage id="stripes-erm-components.doc.name" />}
-              name={`${fields.name}[${i}].name`}
+              name={`${name}[${i}].name`}
               required
               validate={this.validateRequired}
             />
@@ -84,8 +79,8 @@ export default class DocumentsFieldArray extends React.Component {
           <Col xs={1}>
             <IconButton
               icon="trash"
-              id={`${fields.name}-delete-${i}`}
-              onClick={() => this.handleDeleteDoc(i, doc)}
+              id={`${name}-delete-${i}`}
+              onClick={() => onDeleteField(i, doc)}
             />
           </Col>
         </Row>
@@ -93,9 +88,9 @@ export default class DocumentsFieldArray extends React.Component {
           <Col xs={11}>
             <Field
               component={TextArea}
-              id={`${fields.name}-note-${i}`}
+              id={`${name}-note-${i}`}
               label={<FormattedMessage id="stripes-erm-components.doc.note" />}
-              name={`${fields.name}[${i}].note`}
+              name={`${name}[${i}].note`}
             />
           </Col>
         </Row>
@@ -103,9 +98,9 @@ export default class DocumentsFieldArray extends React.Component {
           <Col xs={11}>
             <Field
               component={TextField}
-              id={`${fields.name}-location-${i}`}
+              id={`${name}-location-${i}`}
               label={<FormattedMessage id="stripes-erm-components.doc.location" />}
-              name={`${fields.name}[${i}].location`}
+              name={`${name}[${i}].location`}
               validate={this.validateDocIsSpecified}
             />
           </Col>
@@ -114,9 +109,9 @@ export default class DocumentsFieldArray extends React.Component {
           <Col xs={11}>
             <Field
               component={TextField}
-              id={`${fields.name}-url-${i}`}
+              id={`${name}-url-${i}`}
               label={<FormattedMessage id="stripes-erm-components.doc.url" />}
-              name={`${fields.name}[${i}].url`}
+              name={`${name}[${i}].url`}
               validate={[
                 this.validateDocIsSpecified,
                 this.validateURLIsValid,
@@ -135,19 +130,19 @@ export default class DocumentsFieldArray extends React.Component {
   )
 
   render() {
-    const { fields } = this.props;
-    const docs = (fields.getAll() || [])
-      .filter(d => d._delete !== true);
+    const { items, name, onAddField } = this.props;
 
     return (
       <div>
         <div>
-          { docs.length ? this.renderDocs(docs) : this.renderEmpty() }
+          { items.length ? this.renderDocs() : this.renderEmpty() }
         </div>
-        <Button id={`add-${fields.name}-btn`} onClick={() => fields.push({})}>
+        <Button id={`add-${name}-btn`} onClick={() => onAddField({})}>
           { this.props.addDocBtnLabel }
         </Button>
       </div>
     );
   }
 }
+
+export default withKiwtFieldArray(DocumentsFieldArray);

--- a/lib/withKiwtFieldArray/index.js
+++ b/lib/withKiwtFieldArray/index.js
@@ -1,0 +1,1 @@
+export { default } from './withKiwtFieldArray';

--- a/lib/withKiwtFieldArray/readme.md
+++ b/lib/withKiwtFieldArray/readme.md
@@ -1,0 +1,67 @@
+# withKiwtFieldArray
+
+A higher-order component to simplify the interface between redux-form `<FieldArray>` and arrays in a backend module that uses the [K-Int Web Toolkit](https://github.com/k-int/web-toolkit-ce/) to manage its arrays via the [ExtendedWebDataBinder](https://github.com/k-int/web-toolkit-ce/blob/master/src/main/groovy/com/k_int/web/toolkit/databinding/ExtendedWebDataBinder.groovy).
+
+The key difference for UI code talking to those modules instead of classical FOLIO RMB modules, is that when PUTing an updated record with arrays of objects, only the objects that have changed need to sent to minimise payload size.
+
+This also means that when deleting an object from an array, simply omitting the object is not enough. Instead an object should be sent back with the `id` of the object being deleted, and a `_delete` flag set to `true`. Consider the following:
+
+```
+{
+  items: [
+    {
+      "id": "a",
+      "value": "newValue"
+    },
+    {
+      "id", "c",
+      "_delete": true
+    }
+  ]
+}
+```
+
+If the `items` array originally included objects with `id`s `a`, `b`, and `c`, the value of `a` would be updated, `b` would remain unchanged, and `c` would be deleted.
+
+Since FOLIO form array components do not natively set a `_delete` flag, the process of marking objects for deletion and filtering out objects marked for deletion when rendering needs to be handled. This [higher-order component](https://reactjs.org/docs/higher-order-components.html) allows developers to abstract this logic away.
+
+## Basic Usage
+
+```
+import withKiwtFieldArray from '@folio/stripes-erm-components';
+
+class UsersFieldArray extends React.Component {
+  ...
+
+  render() {
+    return (
+      <React.Fragment>
+      { this.props.items.map((item, index) => (
+        <Item
+          item={item}
+          key={index}
+          onDelete={() => this.props.onDeleteField(index, item)}
+        />
+      )); }
+      <Button
+        onClick={() => { this.props.onAddField({}); } }
+      >Add Item<Button>
+      </React.Fragment>
+    )
+  }
+}
+
+export default withKiwtFieldArray(UsersFieldArray)
+```
+
+## Props Provided to the Wrapped Component
+| name | type | description |
+| ---- | ---- | ----------- |
+| items | array | Array of items to be rendered and not marked for deletion |
+| name | string | The `name` provided by a parent component when hooking your component to a redux-form `FieldArray`. Provided here for convenience rather than `fields.name`. |
+| onAddField | function (defaultObject = {}) => {} | Should be called when you want to add a new item to the array. Optionally pass in an object with default values for any keys. **Note** that if you pass this to a click-handler without a wrapper function, the click-handler will pass the `event` as the default object. So you should probably always be calling this function yourself rather than passing it somewhere and letting some other code call it. |
+| onDeleteField | function (index, objectToBeDeleted) => {} | Should be called when deleting an object from the array. **Both parameters are required.** |
+| onReplaceField | function (index, objectToBeInserted) => {} | Should be called when attempting to replace an object in the array with another object. Generally not used since you usually have separate form components that target specific keys within an object, but this can be useful when completely swapping out entries or setting keys in bulk. **Both parameters are required.** |
+| fields | object | The redux-form `fields` prop is passed down as-is, in case you need anything from it. Naturally, this requires that you've connected your component to a redux-form `FieldArray`. |
+| meta | object | The redux-form `meta` prop is passed down as-is, in case you need anything from it. Naturally, this requires that you've connected your component to a redux-form `FieldArray`. |
+| *other* | - | All other props are also passed down. |

--- a/lib/withKiwtFieldArray/withKiwtFieldArray.js
+++ b/lib/withKiwtFieldArray/withKiwtFieldArray.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const getDisplayName = (WrappedComponent) => {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+};
+
+export default function withKiwtFieldArray(WrappedComponent) {
+  class WithKiwtFieldArray extends React.Component {
+    static propTypes = {
+      fields: PropTypes.shape({
+        getAll: PropTypes.func.isRequired,
+        insert: PropTypes.func.isRequired,
+        name: PropTypes.string.isRequired,
+        push: PropTypes.func.isRequired,
+        remove: PropTypes.func.isRequired,
+      }).isRequired,
+    }
+
+    handleAddField = (field = {}) => {
+      this.props.fields.push(field);
+    }
+
+    handleDeleteField = (index, field) => {
+      const { fields } = this.props;
+
+      fields.remove(index);
+
+      if (field.id) {
+        fields.push({ id: field.id, _delete: true });
+      }
+    }
+
+    handleReplaceField = (index, field) => {
+      this.props.fields.remove(index);
+      this.props.fields.insert(index, field);
+    }
+
+    render() {
+      const { fields } = this.props;
+
+      // Filter away items that have been marked for deletion.
+      const items = (fields.getAll() || []).filter(line => !line._delete);
+
+      return (
+        <WrappedComponent
+          {...this.props}
+          items={items}
+          name={fields.name}
+          onAddField={this.handleAddField}
+          onDeleteField={this.handleDeleteField}
+          onReplaceField={this.handleReplaceField}
+        />
+      );
+    }
+  }
+
+  WithKiwtFieldArray.displayName = `WithKiwtFieldArray(${getDisplayName(WrappedComponent)})`;
+  return WithKiwtFieldArray;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-erm-components",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Component library for Stripes ERM applications",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"


### PR DESCRIPTION
A higher-order component to simplify the interface between redux-form `<FieldArray>` and arrays in a backend module that uses the [K-Int Web Toolkit](https://github.com/k-int/web-toolkit-ce/) to manage its arrays via the [ExtendedWebDataBinder](https://github.com/k-int/web-toolkit-ce/blob/master/src/main/groovy/com/k_int/web/toolkit/databinding/ExtendedWebDataBinder.groovy).

See added readme for more info.