### PR TITLE
ERM-79: set supplementary information for a license

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 # Logs
 logs
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Added `LicenseTermsList` component. Avail in 1.2.1.
 * Added `withKiwtFieldArray` higher-order component. Avail in 1.3.0.
+* Changed `DocumentsFieldArray` component to support `atType`. Avail in 1.3.1.
+* Changed `DocumentCard` component to support `atType`. Avail in 1.3.1.
 
 ## 1.2.0 (18-03-2019)
 

--- a/lib/DocumentCard/DocumentCard.js
+++ b/lib/DocumentCard/DocumentCard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import {
   Col,
@@ -15,7 +16,6 @@ import css from './DocumentCard.css';
 
 export default class DocumentCard extends React.Component {
   static propTypes = {
-    atType: PropTypes.string,
     location: PropTypes.string,
     name: PropTypes.string.isRequired,
     note: PropTypes.string,
@@ -52,7 +52,7 @@ export default class DocumentCard extends React.Component {
 
   render() {
     const { location, name, note, url } = this.props;
-    const category = this.props.atType;
+    const category = get(this.props, ['atType', 'label']);
 
     const contentData = [];
     if (location) contentData.push({ location });

--- a/lib/DocumentCard/DocumentCard.js
+++ b/lib/DocumentCard/DocumentCard.js
@@ -64,7 +64,7 @@ export default class DocumentCard extends React.Component {
           {name}
         </Headline>
         <Row>
-          <Col xs={8}>
+          <Col xs={category ? 8 : 12}>
             {note ?
               <KeyValue label={<FormattedMessage id="stripes-erm-components.doc.note" />}>
                 <div data-test-doc-note>{note}</div>
@@ -73,7 +73,7 @@ export default class DocumentCard extends React.Component {
               null
             }
           </Col>
-          <Col>
+          <Col xs={category ? 4 : 0}>
             {category ?
               <KeyValue label={<FormattedMessage id="stripes-erm-components.doc.category" />}>
                 <div data-test-doc-category>{category}</div>

--- a/lib/DocumentCard/DocumentCard.js
+++ b/lib/DocumentCard/DocumentCard.js
@@ -8,6 +8,7 @@ import {
   KeyValue,
   Layout,
   MultiColumnList,
+  Row,
 } from '@folio/stripes/components';
 
 import css from './DocumentCard.css';
@@ -50,7 +51,8 @@ export default class DocumentCard extends React.Component {
   }
 
   render() {
-    const { atType, location, name, note, url } = this.props;
+    const { location, name, note, url } = this.props;
+    const category = this.props.atType;
 
     const contentData = [];
     if (location) contentData.push({ location });
@@ -61,24 +63,26 @@ export default class DocumentCard extends React.Component {
         <Headline data-test-doc-name={name} margin="none">
           {name}
         </Headline>
-        <Col>
-          {note ?
-            <KeyValue label={<FormattedMessage id="stripes-erm-components.doc.note" />}>
-              <div data-test-doc-note>{note}</div>
-            </KeyValue>
-            :
-            null
-          }
-        </Col>
-        <Col>
-          {atType ?
-            <KeyValue label={<FormattedMessage id="stripes-erm-components.doc.category" />}>
-              <div data-test-doc-category>{atType}</div>
-            </KeyValue>
-            :
-            null
-          }
-        </Col>
+        <Row>
+          <Col xs={8}>
+            {note ?
+              <KeyValue label={<FormattedMessage id="stripes-erm-components.doc.note" />}>
+                <div data-test-doc-note>{note}</div>
+              </KeyValue>
+              :
+              null
+            }
+          </Col>
+          <Col>
+            {category ?
+              <KeyValue label={<FormattedMessage id="stripes-erm-components.doc.category" />}>
+                <div data-test-doc-category>{category}</div>
+              </KeyValue>
+              :
+              null
+            }
+          </Col>
+        </Row>
         <MultiColumnList
           columnMapping={{
             type: <FormattedMessage id="stripes-erm-components.doc.type" />,

--- a/lib/DocumentCard/DocumentCard.js
+++ b/lib/DocumentCard/DocumentCard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import {
+  Col,
   Headline,
   Icon,
   KeyValue,
@@ -13,6 +14,7 @@ import css from './DocumentCard.css';
 
 export default class DocumentCard extends React.Component {
   static propTypes = {
+    atType: PropTypes.string,
     location: PropTypes.string,
     name: PropTypes.string.isRequired,
     note: PropTypes.string,
@@ -48,7 +50,7 @@ export default class DocumentCard extends React.Component {
   }
 
   render() {
-    const { location, name, note, url } = this.props;
+    const { atType, location, name, note, url } = this.props;
 
     const contentData = [];
     if (location) contentData.push({ location });
@@ -59,13 +61,24 @@ export default class DocumentCard extends React.Component {
         <Headline data-test-doc-name={name} margin="none">
           {name}
         </Headline>
-        {note ?
-          <KeyValue label={<FormattedMessage id="stripes-erm-components.doc.note" />}>
-            <div data-test-doc-note>{note}</div>
-          </KeyValue>
-          :
-          null
-        }
+        <Col>
+          {note ?
+            <KeyValue label={<FormattedMessage id="stripes-erm-components.doc.note" />}>
+              <div data-test-doc-note>{note}</div>
+            </KeyValue>
+            :
+            null
+          }
+        </Col>
+        <Col>
+          {atType ?
+            <KeyValue label={<FormattedMessage id="stripes-erm-components.doc.category" />}>
+              <div data-test-doc-category>{atType}</div>
+            </KeyValue>
+            :
+            null
+          }
+        </Col>
         <MultiColumnList
           columnMapping={{
             type: <FormattedMessage id="stripes-erm-components.doc.type" />,

--- a/lib/DocumentsFieldArray/DocumentsFieldArray.js
+++ b/lib/DocumentsFieldArray/DocumentsFieldArray.js
@@ -67,13 +67,19 @@ class DocumentsFieldArray extends React.Component {
     return (
       <Row>
         <Col xs={11}>
-          <Field
-            component={Select}
-            dataOptions={documentCategories}
-            id={`${name}-category-${i}`}
-            label={<FormattedMessage id="stripes-erm-components.doc.category" />}
-            name={`${name}[${i}].atType`}
-          />
+          <FormattedMessage id="ui-licenses.placeholder.documentCategory">
+            {placeholder => (
+              <Field
+                component={Select}
+                dataOptions={documentCategories}
+                id={`${name}-category-${i}`}
+                label={<FormattedMessage id="stripes-erm-components.doc.category" />}
+                name={`${name}[${i}].atType`}
+                placeholder={placeholder}
+                value="no"
+              />
+            )}
+          </FormattedMessage>
         </Col>
       </Row>
     );

--- a/lib/DocumentsFieldArray/DocumentsFieldArray.js
+++ b/lib/DocumentsFieldArray/DocumentsFieldArray.js
@@ -7,11 +7,12 @@ import { Field } from 'redux-form';
 import {
   Button,
   Col,
+  IconButton,
   Layout,
   Row,
+  Select,
   TextArea,
   TextField,
-  IconButton,
 } from '@folio/stripes/components';
 
 import withKiwtFieldArray from '../withKiwtFieldArray';
@@ -26,6 +27,7 @@ class DocumentsFieldArray extends React.Component {
     name: PropTypes.string.isRequired,
     onAddField: PropTypes.func.isRequired,
     onDeleteField: PropTypes.func.isRequired,
+    documentCategories: PropTypes.arrayOf(PropTypes.object),
   }
 
   static defaultProps = {
@@ -60,8 +62,25 @@ class DocumentsFieldArray extends React.Component {
     !value ? <FormattedMessage id="stripes-core.label.missingRequiredField" /> : undefined
   )
 
+  renderCategory = (i) => {
+    const { documentCategories, name } = this.props;
+    return (
+      <Row>
+        <Col xs={11}>
+          <Field
+            component={Select}
+            dataOptions={documentCategories}
+            id={`${name}-category-${i}`}
+            label={<FormattedMessage id="stripes-erm-components.doc.category" />}
+            name={`${name}[${i}].atType`}
+          />
+        </Col>
+      </Row>
+    );
+  }
+
   renderDocs = () => {
-    const { items, name, onDeleteField } = this.props;
+    const { documentCategories, items, name, onDeleteField } = this.props;
 
     return items.map((doc, i) => (
       <div className={css.doc} key={i}>
@@ -84,6 +103,7 @@ class DocumentsFieldArray extends React.Component {
             />
           </Col>
         </Row>
+        { documentCategories ? this.renderCategory(i) : '' }
         <Row>
           <Col xs={11}>
             <Field

--- a/lib/DocumentsFieldArray/DocumentsFieldArray.js
+++ b/lib/DocumentsFieldArray/DocumentsFieldArray.js
@@ -76,7 +76,6 @@ class DocumentsFieldArray extends React.Component {
                 label={<FormattedMessage id="stripes-erm-components.doc.category" />}
                 name={`${name}[${i}].atType`}
                 placeholder={placeholder}
-                value="no"
               />
             )}
           </FormattedMessage>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-erm-components",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Component library for Stripes ERM applications",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"

--- a/translations/stripes-erm-components/en.json
+++ b/translations/stripes-erm-components/en.json
@@ -14,6 +14,7 @@
   "licenseTermsList.notSet": "Not set",
 
   "doc.addDoc": "Add  document",
+  "doc.category": "Category",
   "doc.location": "Physical location",
   "doc.name": "Name",
   "doc.note": "Note",


### PR DESCRIPTION
* modify DocumentCard and DocumentFieldArray components to support supplementary information with document categories
* add minor version 1.3.1 to CHANGELOG.md and package.json
* add doc.category to en.json
* add .DS_Store to .gitignore
