### PR TITLE
getSASParams: Add `queryGetter` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added `Tags` component. Avail in 1.3.1.
 * Changed `DocumentsFieldArray` component to support `atType`. Avail in 1.3.2.
 * Changed `DocumentCard` component to support `atType`. Avail in 1.3.2.
+* Added `queryGetter` option to `getSASParams`. Avail in 1.3.3.
 
 ## 1.2.0 (18-03-2019)
 

--- a/lib/DocumentsFieldArray/DocumentsFieldArray.js
+++ b/lib/DocumentsFieldArray/DocumentsFieldArray.js
@@ -27,7 +27,10 @@ class DocumentsFieldArray extends React.Component {
     name: PropTypes.string.isRequired,
     onAddField: PropTypes.func.isRequired,
     onDeleteField: PropTypes.func.isRequired,
-    documentCategories: PropTypes.arrayOf(PropTypes.object),
+    documentCategories: PropTypes.arrayOf(PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.string,
+    })),
   }
 
   static defaultProps = {
@@ -108,7 +111,7 @@ class DocumentsFieldArray extends React.Component {
             />
           </Col>
         </Row>
-        { documentCategories ? this.renderCategory(i) : '' }
+        { documentCategories ? this.renderCategory(i) : null }
         <Row>
           <Col xs={11}>
             <Field

--- a/lib/getSASParams.js
+++ b/lib/getSASParams.js
@@ -4,13 +4,14 @@ export default (options) => (queryParams, pathComponents, resources) => {
     columnMap = {},
     filterKeys = {},
     filterConfig = [],
+    queryGetter = (r) => r.query,
   } = options;
 
   const params = {
     stats: 'true',
   };
 
-  const { query: { qindex, query, filters, sort } } = resources;
+  const { qindex, query, filters, sort } = queryGetter(resources);
 
   if (query) {
     params.match = (qindex || searchKey).split(',');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-erm-components",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Component library for Stripes ERM applications",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"


### PR DESCRIPTION
`queryGetter` allows consuming modules to store their query string params in a resource _other_ than `query`. 

This is very useful for plugins.