### PR TITLE
turned off sideEffects to enable tree-shaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Changed `DocumentsFieldArray` component to support `atType`. Avail in 1.3.2.
 * Changed `DocumentCard` component to support `atType`. Avail in 1.3.2.
 * Added `queryGetter` option to `getSASParams`. Avail in 1.3.3.
+* Turned off sideEffects to enable tree-shaking for production builds. Refs STRIPES-564 and STRIPES-581.
 
 ## 1.2.0 (18-03-2019)
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@folio/stripes-erm-components",
   "version": "1.3.3",
   "description": "Component library for Stripes ERM applications",
+  "sideEffects": ["*.css"],
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },


### PR DESCRIPTION
- Tested with sample "Hello World" UI app. No difference in bundle size but this will shake future unused code blocks.