### PR TITLE
ERM-230: Added Card Component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Turned off sideEffects to enable tree-shaking for production builds. Refs STRIPES-564 and STRIPES-581.
 * Added `InternalContactsFieldArray` component. Avail in 1.3.4.
 * Changed `LicenseTermsList` component to render `note`. Avail in 1.3.5.
+* Added `Card` component. Avail in 1.3.5.
 
 ## 1.2.0 (18-03-2019)
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 // Components
+export { default as Card } from './lib/Card';
 export { default as CreateOrganizationModal } from './lib/CreateOrganizationModal';
 export { default as DocumentCard } from './lib/DocumentCard';
 export { default as DocumentsFieldArray } from './lib/DocumentsFieldArray';

--- a/lib/Card/Card.css
+++ b/lib/Card/Card.css
@@ -17,12 +17,7 @@
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  padding: 0 14px;
-}
-
-.headerDelete {
-  margin: 0 0 0 auto; /* align to end of header */
-  padding: 4px 0;
+  padding: 8px var(--gutter);
 }
 
 .body {

--- a/lib/Card/Card.css
+++ b/lib/Card/Card.css
@@ -1,0 +1,32 @@
+@import '@folio/stripes-components/lib/variables';
+
+.card {
+  width: 100%;
+  border-color: var(--color-border-p2);
+  border-width: 1px 1px 0;
+  border-style: solid;
+
+  &:last-of-type {
+    border-bottom: 1px solid var(--color-border-p2);
+    margin-bottom: 4px;
+  }
+}
+
+.header {
+  background-color: var(--bg-hover);
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 0 14px;
+}
+
+.headerDelete {
+  margin: 0 0 0 auto; /* align to end of header */
+  padding: 4px 0;
+}
+
+.body {
+  padding: 14px;
+  background-color: color(var(--bg) blend(var(--bg-hover) 20%));
+  width: 100%;
+}

--- a/lib/Card/Card.js
+++ b/lib/Card/Card.js
@@ -21,7 +21,6 @@ export default class Card extends React.Component {
         <div
           className={css.header}
           data-test-card-header
-          start="xs"
         >
           {header}
         </div>

--- a/lib/Card/Card.js
+++ b/lib/Card/Card.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import css from './Card.css';
+
+export default class Card extends React.Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    header: PropTypes.node.isRequired,
+  }
+
+  render() {
+    const {
+      children,
+      header,
+      ...rest
+    } = this.props;
+
+    return (
+      <div className={css.card} {...rest}>
+        <div
+          className={css.header}
+          data-test-card-header
+          start="xs"
+        >
+          {header}
+        </div>
+        <div
+          data-test-card-body
+          className={css.body}
+        >
+          {children}
+        </div>
+      </div>
+    );
+  }
+}

--- a/lib/Card/index.js
+++ b/lib/Card/index.js
@@ -1,0 +1,1 @@
+export { default } from './Card';

--- a/lib/Card/readme.md
+++ b/lib/Card/readme.md
@@ -1,0 +1,29 @@
+# Card
+
+Renders a card that's generally used for displaying lists of complex objects of key-value pairs.
+
+## Basic Usage
+
+The component itself only sets up the styling of the card and the contents are completely up to the user. E.g.,
+```
+<Card
+  id="my-card"
+  header={
+    <React.Fragment>
+      <span className="my-card-header">My Header<span>
+      <button>Click Me!</button>
+    </React.Fragment>
+  }
+>
+  <div>This is my card body content!</div>
+</Card>
+```
+
+## Props
+
+| Name | Type | Required | Note |
+--- | --- | --- | --- |
+| `children` | node | Yes |
+| `header` | node | Yes |
+| _rest_ | | | Other props will be applied to the top-level card `div`. |
+

--- a/lib/Card/tests/Card-test.js
+++ b/lib/Card/tests/Card-test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { mountWithContext } from '../../../tests/helpers';
+
+import CardInteractor from './interactor';
+import Card from '../Card';
+
+const card = new CardInteractor();
+
+const props = {
+  header: 'Test Header',
+  body: 'Test Body',
+};
+
+describe.only('Card', () => {
+  describe('rendering', () => {
+    beforeEach(async () => {
+      const { body, ...rest } = props;
+
+      await mountWithContext(
+        <Card {...rest}>{body}</Card>
+      );
+    });
+
+    it('renders a header', () => {
+      expect(card.isHeaderPresent).to.be.true;
+    });
+
+    it('renders header according to prop', () => {
+      expect(card.header).to.equal(props.header);
+    });
+
+    it('renders a body', () => {
+      expect(card.isBodyPresent).to.be.true;
+    });
+
+    it('renders body according to children', () => {
+      expect(card.body).to.equal(props.body);
+    });
+  });
+});

--- a/lib/Card/tests/interactor.js
+++ b/lib/Card/tests/interactor.js
@@ -1,0 +1,17 @@
+import {
+  interactor,
+  text,
+  isPresent,
+} from '@bigtest/interactor';
+
+import css from '../Card.css';
+
+@interactor class CardInteractor {
+  static defaultScope = `.${css.card}`
+  isHeaderPresent = isPresent('[data-test-card-header]');
+  header = text('[data-test-card-header]');
+  isBodyPresent = isPresent('[data-test-card-body]');
+  body = text('[data-test-card-body]');
+}
+
+export default CardInteractor;


### PR DESCRIPTION
Added a basic `Card` component to let us render the card-based layouts we're about to start using often in ERM apps. This was inspired by the address edit UI in the Users app and picked up by our UX designer after consultation with Filip.

**Basic Usage**
<img width="724" alt="test-card" src="https://user-images.githubusercontent.com/5324374/57795453-077a0800-7714-11e9-804b-fb2aa4770d22.png">

**In The Wild**
<img width="767" alt="card" src="https://user-images.githubusercontent.com/5324374/57795128-317efa80-7713-11e9-8fc6-b5836221eedf.png">

Eventually, I believe this is a candidate for being in @folio-org/stripes itself.