### PR TITLE
DFA: Hide document categories when empty

### DIFF
--- a/lib/DocumentsFieldArray/DocumentsFieldArray.js
+++ b/lib/DocumentsFieldArray/DocumentsFieldArray.js
@@ -69,6 +69,9 @@ class DocumentsFieldArray extends React.Component {
 
   renderCategory = (i) => {
     const { documentCategories, name } = this.props;
+
+    if (get(documentCategories, 'length', 0) === 0) return null;
+
     return (
       <Row>
         <Col xs={12}>
@@ -92,7 +95,6 @@ class DocumentsFieldArray extends React.Component {
 
   renderDocs = () => {
     const {
-      documentCategories,
       onDeleteFile,
       onDownloadFile,
       onUploadFile,
@@ -124,7 +126,7 @@ class DocumentsFieldArray extends React.Component {
                 />
               </Col>
             </Row>
-            { documentCategories ? this.renderCategory(i) : null }
+            { this.renderCategory(i) }
             <Row>
               <Col xs={12}>
                 <Field

--- a/lib/DocumentsFieldArray/FileUploaderFieldView.js
+++ b/lib/DocumentsFieldArray/FileUploaderFieldView.js
@@ -15,7 +15,7 @@ export default class FileUploaderFieldView extends React.Component {
   static propTypes = {
     error: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
     file: PropTypes.shape({
-      modified: PropTypes.string,
+      modified: PropTypes.number,
       name: PropTypes.string,
     }).isRequired,
     isDropZoneActive: PropTypes.bool,

--- a/lib/DocumentsFieldArray/FileUploaderFieldView.js
+++ b/lib/DocumentsFieldArray/FileUploaderFieldView.js
@@ -15,7 +15,7 @@ export default class FileUploaderFieldView extends React.Component {
   static propTypes = {
     error: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
     file: PropTypes.shape({
-      modified: PropTypes.number,
+      modified: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
       name: PropTypes.string,
     }).isRequired,
     isDropZoneActive: PropTypes.bool,

--- a/lib/DocumentsFieldArray/tests/DocumentsFieldArray-test.js
+++ b/lib/DocumentsFieldArray/tests/DocumentsFieldArray-test.js
@@ -25,7 +25,7 @@ const isEmptyMessage = 'No documents';
 const interactor = new DocumentsFieldArrayInteractor();
 const uploaderInteractor = new FileUploaderInteractor();
 
-describe('DocumentsFieldArray', () => {
+describe.only('DocumentsFieldArray', () => {
   beforeEach(async () => {
     await mountWithContext(
       <TestForm>
@@ -39,6 +39,7 @@ describe('DocumentsFieldArray', () => {
           isEmptyMessage={isEmptyMessage}
           name="DocumentsFieldArrayTest"
           onDeleteFile={onDeleteFile}
+          onDownloadFile={onDownloadFile}
           onUploadFile={onUploadFile}
         />
       </TestForm>
@@ -302,6 +303,7 @@ describe('DocumentsFieldArray', () => {
             isEmptyMessage={isEmptyMessage}
             name="docs"
             onDeleteFile={onDeleteFile}
+            onDownloadFile={onDownloadFile}
             onUploadFile={onUploadFileError}
           />
         </TestForm>
@@ -331,6 +333,7 @@ describe('DocumentsFieldArray', () => {
             isEmptyMessage={isEmptyMessage}
             name="docs"
             onDeleteFile={onDeleteFileError}
+            onDownloadFile={onDownloadFile}
             onUploadFile={onUploadFile}
           />
         </TestForm>
@@ -357,6 +360,64 @@ describe('DocumentsFieldArray', () => {
           expect(uploaderInteractor.hasError).to.be.true;
         });
       });
+    });
+  });
+
+  describe('omitting optional props', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <TestForm>
+          <FieldArray
+            addDocBtnLabel={addDocBtnLabel}
+            component={DocumentsFieldArray}
+            documentCategories={[]}
+            isEmptyMessage={isEmptyMessage}
+            name="DocumentsFieldArrayTest"
+          />
+        </TestForm>
+      );
+      await interactor.clickAddButton();
+    });
+  });
+
+  describe('basic rendering', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <TestForm>
+          <FieldArray
+            component={DocumentsFieldArray}
+            name="DocumentsFieldArrayTest"
+          />
+        </TestForm>
+      );
+      await interactor.clickAddButton();
+    });
+
+    it('does not render a category field', () => {
+      expect(interactor.hasCategory).to.be.false;
+    });
+
+    it('does not render a file field', () => {
+      expect(interactor.hasFile).to.be.false;
+    });
+  });
+
+  describe('passing an empty categories array', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <TestForm>
+          <FieldArray
+            component={DocumentsFieldArray}
+            name="DocumentsFieldArrayTest"
+            documentCategories={[]}
+          />
+        </TestForm>
+      );
+      await interactor.clickAddButton();
+    });
+
+    it('does not render a category field', () => {
+      expect(interactor.hasCategory).to.be.false;
     });
   });
 });

--- a/lib/DocumentsFieldArray/tests/DocumentsFieldArray-test.js
+++ b/lib/DocumentsFieldArray/tests/DocumentsFieldArray-test.js
@@ -25,7 +25,7 @@ const isEmptyMessage = 'No documents';
 const interactor = new DocumentsFieldArrayInteractor();
 const uploaderInteractor = new FileUploaderInteractor();
 
-describe.only('DocumentsFieldArray', () => {
+describe('DocumentsFieldArray', () => {
   beforeEach(async () => {
     await mountWithContext(
       <TestForm>


### PR DESCRIPTION
- Hide document category selector when the array is empty as well as undefined.
- Tweak proptypes for file modified timestamp.
- Default rendering tests