### PR TITLE
FUF: Mark files for deletion on submit

### DIFF
--- a/lib/DocumentsFieldArray/DocumentsFieldArray.js
+++ b/lib/DocumentsFieldArray/DocumentsFieldArray.js
@@ -21,7 +21,6 @@ import withKiwtFieldArray from '../withKiwtFieldArray';
 class DocumentsFieldArray extends React.Component {
   static propTypes = {
     addDocBtnLabel: PropTypes.node,
-    onDeleteFile: PropTypes.func,
     onDownloadFile: PropTypes.func,
     onUploadFile: PropTypes.func,
     isEmptyMessage: PropTypes.node,
@@ -95,7 +94,6 @@ class DocumentsFieldArray extends React.Component {
 
   renderDocs = () => {
     const {
-      onDeleteFile,
       onDownloadFile,
       onUploadFile,
       items,
@@ -152,7 +150,6 @@ class DocumentsFieldArray extends React.Component {
                     id={`${name}-file-${i}`}
                     label={<FormattedMessage id="stripes-erm-components.doc.file" />}
                     name={`${name}[${i}].fileUpload`}
-                    onDeleteFile={onDeleteFile}
                     onDownloadFile={onDownloadFile}
                     onUploadFile={onUploadFile}
                     validate={this.validateDocIsSpecified}

--- a/lib/DocumentsFieldArray/FileUploaderField.js
+++ b/lib/DocumentsFieldArray/FileUploaderField.js
@@ -65,21 +65,24 @@ class FileUploaderField extends React.Component {
   }
 
   handleDelete = (file) => {
-    this.props.onDeleteFile(file)
-      .then(response => {
-        if (response.status >= 400) {
-          throw new Error(`${response.statusText} (${response.status})`);
-        }
+    this.props.input.onChange('');
+    this.setState({ file: {} });
 
-        this.props.input.onChange(undefined);
-        this.setState({ file: {} });
-      }).catch(error => {
-        console.error(error); // eslint-disable-line no-console
-        this.setState({
-          error: error.message,
-          file: {},
-        });
-      });
+    // this.props.onDeleteFile(file)
+    //   .then(response => {
+    //     if (response.status >= 400) {
+    //       throw new Error(`${response.statusText} (${response.status})`);
+    //     }
+
+    //     this.props.input.onChange('');
+    //     this.setState({ file: {} });
+    //   }).catch(error => {
+    //     console.error(error); // eslint-disable-line no-console
+    //     this.setState({
+    //       error: error.message,
+    //       file: {},
+    //     });
+    //   });
   }
 
   render() {

--- a/lib/DocumentsFieldArray/FileUploaderField.js
+++ b/lib/DocumentsFieldArray/FileUploaderField.js
@@ -7,7 +7,6 @@ import FileUploaderFieldView from './FileUploaderFieldView';
 
 class FileUploaderField extends React.Component {
   static propTypes = {
-    onDeleteFile: PropTypes.func.isRequired,
     onDownloadFile: PropTypes.func.isRequired,
     onUploadFile: PropTypes.func.isRequired,
     input: PropTypes.shape({
@@ -64,25 +63,9 @@ class FileUploaderField extends React.Component {
       });
   }
 
-  handleDelete = (file) => {
+  handleDelete = () => {
     this.props.input.onChange(null);
     this.setState({ file: {} });
-
-    // this.props.onDeleteFile(file)
-    //   .then(response => {
-    //     if (response.status >= 400) {
-    //       throw new Error(`${response.statusText} (${response.status})`);
-    //     }
-
-    //     this.props.input.onChange('');
-    //     this.setState({ file: {} });
-    //   }).catch(error => {
-    //     console.error(error); // eslint-disable-line no-console
-    //     this.setState({
-    //       error: error.message,
-    //       file: {},
-    //     });
-    //   });
   }
 
   render() {

--- a/lib/DocumentsFieldArray/FileUploaderField.js
+++ b/lib/DocumentsFieldArray/FileUploaderField.js
@@ -65,7 +65,7 @@ class FileUploaderField extends React.Component {
   }
 
   handleDelete = (file) => {
-    this.props.input.onChange('');
+    this.props.input.onChange(null);
     this.setState({ file: {} });
 
     // this.props.onDeleteFile(file)

--- a/lib/DocumentsFieldArray/readme.md
+++ b/lib/DocumentsFieldArray/readme.md
@@ -9,7 +9,7 @@ As with any redux-form field, it's required to pass in a `name` to the parent `F
 
 `addDocBtnLabel` and `isEmptyMessage` can be optionally included to override the default labels.
 
-`onDeleteFile`, `onDownloadFile`, `onUploadFile` should either all be set or all undefined. If defined, they show the file uploader field for each doc to allow users to upload files for attaching to the document.
+`onDownloadFile`, `onUploadFile` should either all be set or all undefined. If defined, they show the file uploader field for each doc to allow users to upload files for attaching to the document.
 
 ### onUploadFile
 
@@ -34,7 +34,6 @@ import { FieldArray } from 'redux-form';
 | `addDocBtnLabel` | string | |
 | `isEmptyMessage` | string | |
 | `name` | string | Yes |
-| `onDeleteFile` | function: (file) => Promise | |
 | `onDownloadFile` | function: (file) => {} | |
 | `onUploadFile` | function: (file) => Promise | |
 

--- a/lib/DocumentsFieldArray/tests/DocumentsFieldArray-test.js
+++ b/lib/DocumentsFieldArray/tests/DocumentsFieldArray-test.js
@@ -13,11 +13,9 @@ chai.use(spies);
 const { expect, spy } = chai;
 
 const uploadedFile = { id: '1', name: 'Test File', modified: Date.now() };
-const onDeleteFile = spy(() => Promise.resolve({}));
 const onDownloadFile = spy();
 const onUploadFile = spy(() => Promise.resolve(uploadedFile));
 const onUploadFileError = spy(() => Promise.resolve({ error: 400, message: 'Upload Error' }));
-const onDeleteFileError = spy(() => Promise.resolve({ status: 400, statusText: 'Delete Error' }));
 
 const addDocBtnLabel = 'Add document';
 const isEmptyMessage = 'No documents';
@@ -25,7 +23,7 @@ const isEmptyMessage = 'No documents';
 const interactor = new DocumentsFieldArrayInteractor();
 const uploaderInteractor = new FileUploaderInteractor();
 
-describe('DocumentsFieldArray', () => {
+describe.only('DocumentsFieldArray', () => {
   beforeEach(async () => {
     await mountWithContext(
       <TestForm>
@@ -38,7 +36,6 @@ describe('DocumentsFieldArray', () => {
           ]}
           isEmptyMessage={isEmptyMessage}
           name="DocumentsFieldArrayTest"
-          onDeleteFile={onDeleteFile}
           onDownloadFile={onDownloadFile}
           onUploadFile={onUploadFile}
         />
@@ -273,10 +270,6 @@ describe('DocumentsFieldArray', () => {
             await interactor.file.delete();
           });
 
-          it('calls onDeleteFile', () => {
-            expect(onDeleteFile).to.be.called();
-          });
-
           it('does not render file name', () => {
             expect(interactor.file.hasFilename).to.be.false;
           });
@@ -302,7 +295,6 @@ describe('DocumentsFieldArray', () => {
             component={DocumentsFieldArray}
             isEmptyMessage={isEmptyMessage}
             name="docs"
-            onDeleteFile={onDeleteFile}
             onDownloadFile={onDownloadFile}
             onUploadFile={onUploadFileError}
           />
@@ -319,46 +311,6 @@ describe('DocumentsFieldArray', () => {
 
       it('should show an error', () => {
         expect(uploaderInteractor.hasError).to.be.true;
-      });
-    });
-  });
-
-  describe('error on delete', () => {
-    beforeEach(async () => {
-      await mountWithContext(
-        <TestForm>
-          <FieldArray
-            addDocBtnLabel={addDocBtnLabel}
-            component={DocumentsFieldArray}
-            isEmptyMessage={isEmptyMessage}
-            name="docs"
-            onDeleteFile={onDeleteFileError}
-            onDownloadFile={onDownloadFile}
-            onUploadFile={onUploadFile}
-          />
-        </TestForm>
-      );
-    });
-
-    describe('dropping a file', () => {
-      beforeEach(async () => {
-        await interactor.clickAddButton();
-        await uploaderInteractor.dragEnter();
-        await uploaderInteractor.drop();
-      });
-
-      it('should not show an error', () => {
-        expect(uploaderInteractor.hasError).to.be.false;
-      });
-
-      describe('deleting the uploaded file', () => {
-        beforeEach(async () => {
-          await interactor.file.delete();
-        });
-
-        it('should show an error', () => {
-          expect(uploaderInteractor.hasError).to.be.true;
-        });
       });
     });
   });


### PR DESCRIPTION
Previously we preemptively and explicitly deleted files using the `onDeleteFile` callback. We've changed the behaviour on the backend as on https://github.com/folio-org/mod-licenses/pull/88 so we're now removing `onDeleteFile` from the API and just marking the `fileUpload` param as `null` when it the delete button is pressed.