### PR TITLE
FUF bug fix & Tags cleanup

### DIFF
--- a/lib/DocumentsFieldArray/FileUploaderField.js
+++ b/lib/DocumentsFieldArray/FileUploaderField.js
@@ -72,7 +72,7 @@ class FileUploaderField extends React.Component {
     return (
       <FileUploaderFieldView
         error={this.props.meta.error || this.state.error}
-        file={this.state.file}
+        file={this.props.input.value ? this.state.file : {}}
         isDropZoneActive={this.state.isDropZoneActive}
         onDelete={this.handleDelete}
         onDownloadFile={this.props.onDownloadFile}

--- a/lib/Tags/Tags.js
+++ b/lib/Tags/Tags.js
@@ -44,42 +44,43 @@ class Tags extends React.Component {
         records: PropTypes.arrayOf(PropTypes.object),
       }),
     }).isRequired,
-    stripes: PropTypes.shape({
-      connect: PropTypes.func.isRequired,
-    }),
   };
 
   constructor(props) {
     super(props);
-    this.onAdd = this.onAdd.bind(this);
-    this.onRemove = this.onRemove.bind(this);
     this.calloutRef = React.createRef();
     this.state = { entity: [] };
   }
 
   static getDerivedStateFromProps(props) {
-    const entities = (props.resources.entities || {}).records || [];
-    const entity = entities[0] || {};
+    const entity = get(props, 'resources.entities.records[0]');
+
     if (entity) return { entity };
+
     return null;
   }
 
-  onAdd(tags) {
+  onAdd = (tags) => {
     this.saveEntityTags(tags);
     this.saveTags(tags);
   }
 
-  onRemove(tag) {
+  onRemove = (tag) => {
     const entity = this.state.entity;
-    const tags = (entity.tags || []);
+    const tags = entity.tags || [];
+
     const tagToDelete = tags.filter(t => t.value.toLowerCase() === tag.toLowerCase());
     const deletedTagList = tags.filter(t => t.value.toLowerCase() !== tag.toLowerCase());
     const updateEntity = cloneDeep(entity);
-    updateEntity.tags = [{ id: tagToDelete[0].id, _delete:true }];
-    this.props.mutator.entities.PUT(updateEntity).then(() => {
-      updateEntity.tags = deletedTagList;
-      this.setState({ entity: updateEntity });
-    });
+
+    const toDelete = [{ id: tagToDelete[0].id, _delete:true }];
+
+    this.props.mutator.entities
+      .PUT({ tags: toDelete })
+      .then(() => {
+        updateEntity.tags = deletedTagList;
+        this.setState({ entity: updateEntity });
+      });
   }
 
   // add tag to the list of entity tags
@@ -88,14 +89,16 @@ class Tags extends React.Component {
     const tagList = (entity.tags || []);
     const tagListMap = tagList.map(tag => ({ 'value': tag.value }));
     const tagsMap = tags.map(tag => ({ 'value': tag.value || tag }));
-    entity.tags = sortBy(uniqBy([...tagListMap, ...tagsMap], 'value'));
-    this.props.mutator.entities.PUT(entity);
+
+    const newTags = sortBy(uniqBy([...tagListMap, ...tagsMap], 'value'));
+
+    this.props.mutator.entities.PUT({ tags: newTags });
   }
 
   // add tags to global list of tags
   saveTags(tags) {
     const { mutator, resources } = this.props;
-    const records = (resources.tags || {}).records || [];
+    const records = get(resources, 'tags.records', []);
     const newTag = difference(tags.map(t => (t.value || t)), records.map(t => t.label.toLowerCase()));
     if (!newTag || !newTag.length) return;
 
@@ -111,26 +114,23 @@ class Tags extends React.Component {
   }
 
   render() {
-    const { resources, stripes } = this.props;
-    const { entity } = this.state;
-    const entityTagsArray = get(entity, ['tags'], []);
-    const entityTags = entityTagsArray.map(tag => tag.value.toLowerCase());
-    const tags = (resources.tags || {}).records || [];
+    const tags = get(this.props.resources, 'tags.records', []);
+    const entityTags = get(this.state.entity, 'tags', [])
+      .map(tag => tag.value.toLowerCase());
 
     return (
       <Pane
         defaultWidth="20%"
-        paneTitle={<FormattedMessage id="stripes-erm-components.tags" />}
-        paneSub={<FormattedMessage id="stripes-erm-components.numberOfTags" values={{ count: entityTags.length }} />}
         dismissible
         onClose={this.props.onToggle}
+        paneSub={<FormattedMessage id="stripes-erm-components.numberOfTags" values={{ count: entityTags.length }} />}
+        paneTitle={<FormattedMessage id="stripes-erm-components.tags" />}
       >
         <TagsForm
-          onRemove={this.onRemove}
-          onAdd={this.onAdd}
-          tags={tags}
           entityTags={entityTags}
-          stripes={stripes}
+          onAdd={this.onAdd}
+          onRemove={this.onRemove}
+          tags={tags}
         />
 
         <Callout ref={this.calloutRef} />


### PR DESCRIPTION
`DocumentsFieldArray` sets each indice's component row with a `key` of the index into the array.

When we have two documents and we delete the first one, the second document "slides up" and during the next render, the components used to render it will have the same key as the components that were used for the first component.  As a result, React will _reuse_ those components directly because of this. 

However, `FileUploadField` stores any uploaded file's information in its internal `state`, which will persist if a component is reused. As a result, that second component that "slid up"? It now inherits the first component's `state`.

To test this, add two documents, upload a file to the first, and then delete it. Note that the second document (now the only one), displays the information about that uploaded file, though redux-form does not have that data set.

To avoid this, we only pass down the `state.file` data to the View component when `FileUploaderField` actually has a `value`.