### PR TITLE
getSASParams passes props into queryGetter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.5.0 (IN PROGRESS)
 
-*
+* `getSASParams` passes props received from stripes-connect into the `queryGetter` callback. Available from v1.4.1.
 
 ## 1.4.0 (11-06-2019)
 

--- a/lib/getSASParams.js
+++ b/lib/getSASParams.js
@@ -1,4 +1,4 @@
-export default (options) => (queryParams, pathComponents, resources) => {
+export default (options) => (queryParams, pathComponents, resources, logger, props) => {
   const {
     searchKey = '',
     columnMap = {},
@@ -11,7 +11,7 @@ export default (options) => (queryParams, pathComponents, resources) => {
     stats: 'true',
   };
 
-  const { qindex, query, filters, sort } = queryGetter(resources);
+  const { qindex, query, filters, sort } = queryGetter(resources, props);
 
   if (query) {
     params.match = (qindex || searchKey).split(',');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-erm-components",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Component library for Stripes ERM applications",
   "sideEffects": [
     "*.css"
@@ -38,6 +38,7 @@
     "redux": "^3.6.0"
   },
   "dependencies": {
+    "@folio/stripes-connect": "^5.2.3",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
     "react-dropzone": "^10.0.0",


### PR DESCRIPTION
This allows client code to decide dynamically how to massage the query based on any prop. Requires a recent stripes-connect (^5.2.3)