### PR TITLE
ERM-319 ERM-320: Link tweaks to License and Organization cards

### DIFF
--- a/lib/LicenseCard/LicenseCard.js
+++ b/lib/LicenseCard/LicenseCard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Link from 'react-router-dom/Link';
 import { get } from 'lodash';
 import { FormattedDate, FormattedMessage } from 'react-intl';
 import { Col, KeyValue, Row } from '@folio/stripes/components';
@@ -54,9 +55,12 @@ export default class LicenseCard extends React.Component {
     return (
       <Row>
         <Col xs={12}>
-          <strong data-test-license-card-name>
+          <Link
+            data-test-license-card-name
+            to={`/licenses/${license.id}`}
+          >
             {license.name}
-          </strong>
+          </Link>
         </Col>
       </Row>
     );

--- a/lib/LicenseCard/tests/LicenseCard-test.js
+++ b/lib/LicenseCard/tests/LicenseCard-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { StaticRouter as Router } from 'react-router-dom';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 import { get } from 'lodash';
@@ -45,7 +46,9 @@ describe('LicenseCard', () => {
   describe('rendering', () => {
     beforeEach(async () => {
       await mountWithContext(
-        <LicenseCard license={license} renderName />
+        <Router context={{}}>
+          <LicenseCard license={license} renderName />
+        </Router>
       );
     });
 

--- a/lib/ViewOrganizationCard/ViewOrganizationCard.js
+++ b/lib/ViewOrganizationCard/ViewOrganizationCard.js
@@ -47,8 +47,12 @@ export default class ViewOrganizationCard extends React.Component {
             name: item => (
               <span>
                 {item.name}
-                <a href={item.uri}>
-                  <Icon icon="external-link" iconPosition="end" />
+                <a
+                  href={item.uri}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <Icon icon="external-link" />
                 </a>
               </span>
             ),

--- a/package.json
+++ b/package.json
@@ -17,16 +17,16 @@
     "lint": "eslint ."
   },
   "devDependencies": {
+    "@bigtest/convergence": "^1.1.1",
     "@bigtest/interactor": "^0.7.2",
+    "@bigtest/mirage": "0.0.1",
     "@bigtest/mocha": "^0.5.0",
     "@bigtest/react": "^0.1.2",
-    "@bigtest/convergence": "^1.1.1",
-    "@bigtest/mirage": "0.0.1",
     "@folio/eslint-config-stripes": "^3.2.1",
     "@folio/stripes": "^2.0.0",
     "@folio/stripes-cli": "^1.10.0",
-    "@folio/stripes-core": "^3.4.0",
     "@folio/stripes-components": "^5.2.0",
+    "@folio/stripes-core": "^3.4.0",
     "babel-eslint": "^9.0.0",
     "babel-polyfill": "^6.26.0",
     "chai": "^4.1.2",
@@ -43,6 +43,7 @@
     "prop-types": "^15.6.0",
     "react-dropzone": "^10.0.0",
     "react-intl": "^2.4.0",
+    "react-router-dom": "^4.1.1",
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
- LicenseCard should render a link to the license record
- Organization's Interface external links should open in a new tab