### PR TITLE
Release 1.5.4

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,10 +3,11 @@
   "extends": "@folio/eslint-config-stripes",
   "overrides": [
     {
-      "files": ["lib/**/tests/*"],
+      "files": ["lib/**/tests/*", "tests/**"],
       "rules": {
-        "no-unused-expressions": "off",
-        "func-names": "off"
+        "import/no-extraneous-dependencies": "off",
+        "func-names": "off",
+        "no-unused-expressions": "off"
       }
     }
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-erm-components
 
+## 1.5.4 2019-07-24
+* Removed `devDependencies` on stripes-components and stripes-core.
+
 ## 1.5.3 2019-07-24
 * `LicenseCard` no longer converts the timezone of the start date.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-erm-components",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Component library for Stripes ERM applications",
   "sideEffects": [
     "*.css"
@@ -25,8 +25,6 @@
     "@folio/eslint-config-stripes": "^3.2.1",
     "@folio/stripes": "^2.0.0",
     "@folio/stripes-cli": "^1.10.0",
-    "@folio/stripes-components": "^5.2.0",
-    "@folio/stripes-core": "^3.4.0",
     "babel-eslint": "^9.0.0",
     "babel-polyfill": "^6.26.0",
     "chai": "^4.1.2",


### PR DESCRIPTION
Removed `devDependencies` on stripes-components and stripes-core.