### PR TITLE
ERM-309: Added InternalContactCard component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.6.0 IN PROGRESS
 * `InternalContactsFieldArray` renders users as a card. ERM-309
 * Bumped `eslint-config-stripes` dependency to 4.2.0
-* Added
+* Added `InternalContactCard` component. ERM-309
 
 ## 1.5.5 2019-08-09
 * Moved `FileUploaderField` into its own component. ERM-337

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ export { default as DocumentsFieldArray } from './lib/DocumentsFieldArray';
 export { default as EditCard } from './lib/EditCard';
 export { default as FileUploader } from './lib/FileUploader';
 export { default as FileUploaderField } from './lib/FileUploaderField';
+export { default as InternalContactCard } from './lib/InternalContactCard';
 export { default as InternalContactsFieldArray } from './lib/InternalContactsFieldArray';
 export { default as OrganizationsFieldArray } from './lib/OrganizationsFieldArray';
 export { default as ViewOrganizationCard } from './lib/ViewOrganizationCard';

--- a/lib/InternalContactCard/InternalContactCard.js
+++ b/lib/InternalContactCard/InternalContactCard.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { AppIcon } from '@folio/stripes/core';
+import { FormattedMessage } from 'react-intl';
+import { get } from 'lodash';
+import { Card, Col, KeyValue, Row } from '@folio/stripes/components';
+
+export default class ContactCard extends React.Component {
+  static propTypes = {
+    contact: PropTypes.shape({
+      role: PropTypes.shape({
+        label: PropTypes.string,
+      }),
+      user: PropTypes.oneOfType([
+        PropTypes.shape({
+          personal: PropTypes.shape({
+            email: PropTypes.string,
+            firstName: PropTypes.string,
+            lastName: PropTypes.string,
+            middleName: PropTypes.string,
+            phone: PropTypes.string,
+          }),
+        }),
+        PropTypes.string,
+      ]),
+    })
+  }
+
+  renderHeader = () => {
+    const { contact } = this.props;
+
+    const {
+      firstName = '',
+      lastName = '-',
+      middleName = '',
+    } = get(contact, 'user.personal', {});
+    const name = `${lastName}${firstName ? ', ' : ' '}${firstName} ${middleName}`;
+
+    const role = get(contact, 'role.label', '');
+    const id = get(contact, 'user.id');
+
+    return (
+      <span data-test-contact-name>
+        <AppIcon
+          app="users"
+          size="small"
+        >
+          <Link
+            data-test-contact-link
+            to={`/users/view/${id}`}
+          >
+            <strong>
+              {name}
+            </strong>
+          </Link>
+          &nbsp;·&nbsp;
+          <span data-test-contact-role>
+            {role}
+          </span>
+        </AppIcon>
+      </span>
+    );
+  }
+
+  render() {
+    const {
+      email = '-',
+      phone = '-',
+    } = get(this.props.contact, 'user.personal', {});
+
+    return (
+      <Card
+        cardStyle="positive"
+        data-test-contact-card
+        hasMargin
+        headerStart={this.renderHeader()}
+        roundedBorder
+      >
+        <Row>
+          <Col xs={4}>
+            <KeyValue label={<FormattedMessage id="stripes-erm-components.contacts.phone" />}>
+              <span data-test-contact-phone>
+                {phone}
+              </span>
+            </KeyValue>
+          </Col>
+          <Col xs={8}>
+            <KeyValue label={<FormattedMessage id="stripes-erm-components.contacts.email" />}>
+              <span data-test-contact-email>
+                {email}
+              </span>
+            </KeyValue>
+          </Col>
+        </Row>
+      </Card>
+    );
+  }
+}

--- a/lib/InternalContactCard/index.js
+++ b/lib/InternalContactCard/index.js
@@ -1,0 +1,1 @@
+export { default } from './InternalContactCard';

--- a/lib/InternalContactCard/tests/InternalContactCard-test.js
+++ b/lib/InternalContactCard/tests/InternalContactCard-test.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import { StaticRouter as Router } from 'react-router-dom';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { mountWithContext } from '../../../tests/helpers';
+
+import InternalContactCard from '..';
+import InternalContactCardInteractor from './interactor';
+
+const interactor = new InternalContactCardInteractor();
+
+describe('InternalContactCard', () => {
+  describe('rendering a fully-defined contact', () => {
+    const contact = {
+      user: {
+        id: '123',
+        personal: {
+          firstName: 'Alice',
+          middleName: 'Alicius',
+          lastName: 'Alicing',
+          phone: '1-416-123-4567',
+          email: 'alice@alicing.ca',
+        },
+      },
+      role: {
+        label: 'CAO',
+      },
+    };
+
+    beforeEach(async () => {
+      await mountWithContext(
+        <Router context={{}}>
+          <InternalContactCard contact={contact} />
+        </Router>
+      );
+    });
+
+    it('renders the card', () => {
+      expect(interactor.exists).to.be.true;
+    });
+
+    it('renders the first name', () => {
+      expect(interactor.name).to.have.string(contact.user.personal.firstName);
+    });
+
+    it('renders the middle name', () => {
+      expect(interactor.name).to.have.string(contact.user.personal.middleName);
+    });
+
+    it('renders the last name', () => {
+      expect(interactor.name).to.have.string(contact.user.personal.lastName);
+    });
+
+    it('renders a link to the user record page', () => {
+      expect(interactor.link).to.have.string(`/users/view/${contact.user.id}`);
+    });
+
+    it('renders the phone number', () => {
+      expect(interactor.phone).to.equal(contact.user.personal.phone);
+    });
+
+    it('renders the email address', () => {
+      expect(interactor.email).to.equal(contact.user.personal.email);
+    });
+  });
+
+  describe('rendering an empty contact', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <Router context={{}}>
+          <InternalContactCard contact={{}} />
+        </Router>
+      );
+    });
+
+    it('renders the card', () => {
+      expect(interactor.exists).to.be.true;
+    });
+
+    it('renders a placeholder name', () => {
+      expect(interactor.name).to.have.string('-');
+    });
+
+    it('renders a placeholder phone number', () => {
+      expect(interactor.phone).to.equal('-');
+    });
+
+    it('renders a placeholder email address', () => {
+      expect(interactor.email).to.equal('-');
+    });
+  });
+});

--- a/lib/InternalContactCard/tests/interactor.js
+++ b/lib/InternalContactCard/tests/interactor.js
@@ -1,0 +1,20 @@
+import {
+  attribute,
+  interactor,
+  isPresent,
+  text,
+} from '@bigtest/interactor';
+
+@interactor class InternalContactCardInteractor {
+  static defaultScope = '[data-test-contact-card]';
+
+  exists = isPresent('div');
+
+  name = text('[data-test-contact-name]');
+  phone = text('[data-test-contact-phone]');
+  email = text('[data-test-contact-email]');
+  role = text('[data-test-contact-role]');
+  link = attribute('[data-test-contact-link]', 'href');
+}
+
+export default InternalContactCardInteractor;


### PR DESCRIPTION
Pretty simple. Basically just renders an internal contact as a Card. Tried to be as flexible as possible with the props coming in and not assume that the currently-required fields are always going to be required.