### PR TITLE
ERM-295: Fixed DFA dropzone resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-erm-components
 
+## 1.7.0 IN PROGRESS
+* Fixed `DocumentsFieldArray` uploader dropzone resizing behaviour. ERM-295
+
 ## 1.6.0 2019-08-20
 * `InternalContactsFieldArray` renders users as a card. ERM-309
 * Bumped `eslint-config-stripes` dependency to 4.2.0

--- a/lib/DocumentsFieldArray/DocumentsFieldArray.js
+++ b/lib/DocumentsFieldArray/DocumentsFieldArray.js
@@ -142,20 +142,16 @@ class DocumentsFieldArray extends React.Component {
           </Col>
           {onUploadFile &&
             <Col xs={12} md={6}>
-              <Row>
-                <Col xs={12}>
-                  <Field
-                    component={FileUploaderField}
-                    data-test-document-field-file
-                    id={`${name}-file-${i}`}
-                    label={<FormattedMessage id="stripes-erm-components.doc.file" />}
-                    name={`${name}[${i}].fileUpload`}
-                    onDownloadFile={onDownloadFile}
-                    onUploadFile={onUploadFile}
-                    validate={this.validateDocIsSpecified}
-                  />
-                </Col>
-              </Row>
+              <Field
+                component={FileUploaderField}
+                data-test-document-field-file
+                id={`${name}-file-${i}`}
+                label={<FormattedMessage id="stripes-erm-components.doc.file" />}
+                name={`${name}[${i}].fileUpload`}
+                onDownloadFile={onDownloadFile}
+                onUploadFile={onUploadFile}
+                validate={this.validateDocIsSpecified}
+              />
             </Col>
           }
         </Row>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-erm-components",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Component library for Stripes ERM applications",
   "sideEffects": [
     "*.css"


### PR DESCRIPTION
This seemed weird at first because the flexbox should automatically keep the div at the same height as its sibling to the left. But the extra Row/Col trashes that flexbox behaviour. Removed the extra Row/Col since it doesn't even do anything.