### PR TITLE
ERM-353 LicenseCard: Maintain search when intralinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.7.0 IN PROGRESS
 * Fixed `DocumentsFieldArray` uploader dropzone resizing behaviour. ERM-295
 * Fixed `withKiwtFieldArray` not handling delete-then-append flows correctly. ERM-420
+* Fixed `LicenseCard` not maintaining query params when linking within Licenses app. ERM-353
 
 ## 1.6.0 2019-08-20
 * `InternalContactsFieldArray` renders users as a card. ERM-309

--- a/lib/LicenseCard/LicenseCard.js
+++ b/lib/LicenseCard/LicenseCard.js
@@ -49,15 +49,18 @@ export default class LicenseCard extends React.Component {
 
   renderName = () => {
     const { license, renderName } = this.props;
+    const { location } = window.document;
 
     if (!renderName) return null;
+
+    const alreadyInLicensesApp = location.pathname.startsWith('/licenses/');
 
     return (
       <Row>
         <Col xs={12}>
           <Link
             data-test-license-card-name
-            to={`/licenses/${license.id}`}
+            to={`/licenses/${license.id}${alreadyInLicensesApp ? location.search : ''}`}
           >
             {license.name}
           </Link>


### PR DESCRIPTION
When viewing a license amendment, we display the license info at the top of the pane. The license info contains the license's name which is a `Link` to the record itself. 

When clicking that link, it strips away any existing query params which resets the SASQ query/filter/sort parameters. **However, it appears this change doesn't get propagated to the filters and search field themselves,** so they do not reflect the list of licenses that's visible in the results MCL.

I'm not sure if that bolded bit is intentional or not, but the behaviour of resetting the query params doesn't feel intuitive or helpful to the user. As a result, I'm working around this by maintaining the query params if we're linking to a License while we're _already in_ the Licenses app.