### PR TITLE
pass rowUpdater prop to MCL to force the re-render when we toggle the…

### DIFF
--- a/lib/ViewOrganizationCard/ViewOrganizationCard.js
+++ b/lib/ViewOrganizationCard/ViewOrganizationCard.js
@@ -111,6 +111,7 @@ export default class ViewOrganizationCard extends React.Component {
             )
           }}
           interactive={false}
+          rowUpdater={(rowData) => hasHideButtonMap[rowData.id]}
           visibleColumns={['name', 'type', 'notes', 'username', 'password', 'showHideButton']}
         />
       </div>


### PR DESCRIPTION
… show/hide credentials button

Pass `rowUpdater` prop to MCL in `ViewOrganizationCard` to force a re-render to show/hide credentials. 

The `RowPositioner` component is a `PureComponent` which basically shallow compares `props` and `state` and if something changes, renders the component.

 `rowUpdater` prop is used here, so that based on the state of the show/hide we return true/false value, and pass this down to MCL, and if this returned value is different value from what it returned in the last update, the row will update.

Logic where this all takes place is [here](https://github.com/folio-org/stripes-components/blob/master/lib/MultiColumnList/MCLRenderer.js#L822)