### PR TITLE
Release 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-erm-components
 
+## 1.7.1 2019-09-09
+* Fixed `UserField` to show error messages.
+
 ## 1.7.0 2019-09-06
 * Fixed `DocumentsFieldArray` uploader dropzone resizing behaviour. ERM-295
 * Fixed `withKiwtFieldArray` not handling delete-then-append flows correctly. ERM-420

--- a/lib/InternalContactsFieldArray/UserField.js
+++ b/lib/InternalContactsFieldArray/UserField.js
@@ -130,7 +130,7 @@ export default class UserField extends React.Component {
     const {
       id,
       input: { value },
-      meta: { error, touched }
+      meta: { dirty, error }
     } = this.props;
 
     return (
@@ -149,7 +149,7 @@ export default class UserField extends React.Component {
         roundedBorder
       >
         { value ? this.renderUser() : this.renderEmpty() }
-        { touched && error ? this.renderError() : null }
+        { dirty && error ? this.renderError() : null }
       </Card>
     );
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-erm-components",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Component library for Stripes ERM applications",
   "sideEffects": [
     "*.css"


### PR DESCRIPTION
### Bugfix release to show errors in `UserField`
`touched` really shouldn't be what we're checking anymore since it remains `false` due to the lack on a `blur` event. `dirty` works better now.