### PR TITLE
Turn off React Intl errors in BigTest

### DIFF
--- a/tests/helpers/turn-off-warnings.js
+++ b/tests/helpers/turn-off-warnings.js
@@ -1,17 +1,29 @@
 /* eslint-disable no-console */
 
 const warn = console.warn;
-const blacklist = [
+const warnBlacklist = [
   /componentWillReceiveProps has been renamed/,
   /componentWillUpdate has been renamed/,
   /componentWillMount has been renamed/,
 ];
 
+const error = console.error;
+const errorBlacklist = [
+  /\[React Intl\]/,
+];
+
 export default function turnOffWarnings() {
   console.warn = function (...args) {
-    if (blacklist.some(rx => rx.test(args[0]))) {
+    if (warnBlacklist.some(rx => rx.test(args[0]))) {
       return;
     }
     warn.apply(console, args);
+  };
+
+  console.error = function (...args) {
+    if (errorBlacklist.some(rx => rx.test(args[0]))) {
+      return;
+    }
+    error.apply(console, args);
   };
 }


### PR DESCRIPTION
They're just console clutter.