### PR TITLE
ERM-564: Support unsetting of optional fields

### DIFF
--- a/lib/DocumentsFieldArray/DocumentsFieldArray.js
+++ b/lib/DocumentsFieldArray/DocumentsFieldArray.js
@@ -87,6 +87,7 @@ class DocumentsFieldArray extends React.Component {
                 id={`${name}-category-${i}`}
                 label={<FormattedMessage id="stripes-erm-components.doc.category" />}
                 name={`${name}[${i}].atType`}
+                parse={v => v} // Lets us send an empty string instead of `undefined`
                 placeholder={placeholder}
               />
             )}
@@ -142,6 +143,7 @@ class DocumentsFieldArray extends React.Component {
                   id={`${name}-note-${i}`}
                   label={<FormattedMessage id="stripes-erm-components.doc.note" />}
                   name={`${name}[${i}].note`}
+                  parse={v => v} // Lets us send an empty string instead of `undefined`
                 />
               </Col>
             </Row>
@@ -169,6 +171,7 @@ class DocumentsFieldArray extends React.Component {
               id={`${name}-location-${i}`}
               label={<FormattedMessage id="stripes-erm-components.doc.location" />}
               name={`${name}[${i}].location`}
+              parse={v => v} // Lets us send an empty string instead of `undefined`
               validate={this.validateDocIsSpecified}
             />
           </Col>
@@ -181,6 +184,7 @@ class DocumentsFieldArray extends React.Component {
               id={`${name}-url-${i}`}
               label={<FormattedMessage id="stripes-erm-components.doc.url" />}
               name={`${name}[${i}].url`}
+              parse={v => v} // Lets us send an empty string instead of `undefined`
               validate={composeValidators(
                 this.validateDocIsSpecified,
                 this.validateURLIsValid,


### PR DESCRIPTION
[ERM-564](https://issues.folio.org/browse/ERM-564)

Backends written in Groovy do not interpret an undefined value as being an "unsetting" of a field. Eg, if a given record has `{ id: 1, foo: "bar", bar: "baz" }` and I PUT `{ id: 1, foo: "aubergine" }`, then the record will now have `{ id: 1, foo: "aubergine", bar: "baz" }`.

This is a problem for us because [React Final Form coalesces empty strings into undefineds](https://final-form.org/docs/final-form/faq#why-does-final-form-set-my--field-value-to-undefined). To work around this, we use [the docs' suggested `parse` hack](https://final-form.org/docs/react-final-form/types/FieldProps#parse).