### PR TITLE
FileUploader: Apply `name` attribute to <button>

### DIFF
--- a/lib/FileUploader/FileUploader.js
+++ b/lib/FileUploader/FileUploader.js
@@ -26,6 +26,7 @@ export default class FileUploader extends React.Component {
     footer: PropTypes.node,
     isDropZoneActive: PropTypes.bool.isRequired,
     maxSize: PropTypes.number,
+    name: PropTypes.string,
     onDragEnter: PropTypes.func,
     onDragLeave: PropTypes.func,
     onDrop: PropTypes.func.isRequired,
@@ -60,6 +61,7 @@ export default class FileUploader extends React.Component {
   renderUploadFields = () => {
     const {
       isDropZoneActive,
+      name,
       uploadButtonAriaLabel,
       uploadButtonText,
       uploadInProgress,
@@ -84,6 +86,7 @@ export default class FileUploader extends React.Component {
           buttonStyle="primary"
           data-test-button
           hidden={isDropZoneActive}
+          name={name}
         >
           {uploadButtonText}
         </Button>

--- a/lib/FileUploaderField/FileUploaderField.js
+++ b/lib/FileUploaderField/FileUploaderField.js
@@ -10,6 +10,7 @@ class FileUploaderField extends React.Component {
     onDownloadFile: PropTypes.func.isRequired,
     onUploadFile: PropTypes.func.isRequired,
     input: PropTypes.shape({
+      name: PropTypes.string,
       onChange: PropTypes.func.isRequired,
       value: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     }).isRequired,
@@ -92,6 +93,7 @@ class FileUploaderField extends React.Component {
             error={this.props.meta.error || this.state.error}
             file={this.props.input.value ? this.state.file : {}}
             isDropZoneActive={this.state.isDropZoneActive}
+            name={this.props.input.name}
             onDelete={this.handleDelete}
             onDownloadFile={this.props.onDownloadFile}
             onDragEnter={() => this.setState({ isDropZoneActive: true })}

--- a/lib/FileUploaderField/FileUploaderFieldView.js
+++ b/lib/FileUploaderField/FileUploaderFieldView.js
@@ -21,6 +21,7 @@ export default class FileUploaderFieldView extends React.Component {
       name: PropTypes.string,
     }).isRequired,
     isDropZoneActive: PropTypes.bool,
+    name: PropTypes.string,
     onDelete: PropTypes.func.isRequired,
     onDownloadFile: PropTypes.func.isRequired,
     onDragEnter: PropTypes.func,
@@ -94,6 +95,7 @@ export default class FileUploaderFieldView extends React.Component {
     const {
       error,
       isDropZoneActive,
+      name,
       onDelete, // eslint-disable-line no-unused-vars
       onDragEnter,
       onDragLeave,
@@ -110,6 +112,7 @@ export default class FileUploaderFieldView extends React.Component {
             footer={this.renderFileInfo()}
             isDropZoneActive={isDropZoneActive}
             multiple={false}
+            name={name}
             onDragEnter={onDragEnter}
             onDragLeave={onDragLeave}
             onDrop={onDrop}


### PR DESCRIPTION
- [stripes-final-form uses final-form-focus to automatically focus the first form element that has an error](https://github.com/folio-org/stripes-final-form/blob/master/lib/StripesFinalFormWrapper.js#L5)
- [final-form-focus finds form elements using this algorithm](https://github.com/final-form/final-form-focus/blob/master/src/findInput.js#L9)
- So we need to set `name` on the form element we want to be autofocused. 
  - We set it on the button since it's the most visible and most obvious for this rask.