### PR TITLE
ERM-603 and ERM-604: PR to change the way organization cards are rendered

### DIFF
--- a/lib/ViewOrganizationCard/ViewOrganizationCard.js
+++ b/lib/ViewOrganizationCard/ViewOrganizationCard.js
@@ -6,8 +6,10 @@ import { get, isEmpty } from 'lodash';
 import {
   Button,
   Card,
+  Col,
   Icon,
   MultiColumnList,
+  Row,
   Tooltip,
 } from '@folio/stripes/components';
 
@@ -142,16 +144,16 @@ export default class ViewOrganizationCard extends React.Component {
   renderOrganizationName = (orgName) => {
     const { id } = this.props;
     return (
-      <span>
-        <AppIcon
-          app="organizations"
-          size="small"
-        >
-          <strong id={id} data-test-org-name>
-            {orgName}
+      <Col >
+        <Row>
+          <strong >
+            Name
           </strong>
-        </AppIcon>
-      </span>
+        </Row>
+        <Row id={id} data-test-org-name>
+          {orgName}
+        </Row>
+      </Col>
     );
   }
 

--- a/lib/ViewOrganizationCard/ViewOrganizationCard.js
+++ b/lib/ViewOrganizationCard/ViewOrganizationCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { AppIcon, IfPermission } from '@folio/stripes/core';
+import { IfPermission } from '@folio/stripes/core';
 import { FormattedMessage } from 'react-intl';
 import { get, isEmpty } from 'lodash';
 import {
@@ -144,9 +144,9 @@ export default class ViewOrganizationCard extends React.Component {
   renderOrganizationName = (orgName) => {
     const { id } = this.props;
     return (
-      <Col >
+      <Col>
         <Row>
-          <strong >
+          <strong>
             Name
           </strong>
         </Row>

--- a/lib/ViewOrganizationCard/ViewOrganizationCard.js
+++ b/lib/ViewOrganizationCard/ViewOrganizationCard.js
@@ -8,6 +8,7 @@ import {
   Card,
   Col,
   Icon,
+  KeyValue,
   MultiColumnList,
   Row,
   Tooltip,
@@ -141,16 +142,15 @@ export default class ViewOrganizationCard extends React.Component {
   renderOrganizationName = (orgName) => {
     const { id } = this.props;
     return (
-      <Col>
-        <Row>
-          <strong>
-            Name
-          </strong>
-        </Row>
-        <Row id={id} data-test-org-name>
-          {orgName}
-        </Row>
-      </Col>
+      <Row id={id}>
+        <Col>
+          <KeyValue label={<FormattedMessage id="stripes-erm-components.viewOrg.name" />}>
+            <span data-test-org-name>
+              {orgName}
+            </span>
+          </KeyValue>
+        </Col>
+      </Row>
     );
   }
 

--- a/translations/stripes-erm-components/en.json
+++ b/translations/stripes-erm-components/en.json
@@ -24,6 +24,8 @@
   "createOrg.createNew": "Create new organization",
   "createOrg.name": "Name",
 
+  "viewOrg.name": "Name",
+
   "fuf.buttonAriaLabel": "Choose file to upload. Maximum file size is 200 megabytes",
   "fuf.filename": "File name",
   "fuf.maxFileSize": "Maximum file size: 200 MB",


### PR DESCRIPTION
This is a little bit of work to change the way that the name of an organization is rendered on an organization card.

I've had some problems getting my agreements form to work, so I've been unable to test whether all tests pass on ui-agreements, but there seem to be no issues in stripes-erm-components or ui-licenses using this, at least for me locally.