### PR TITLE
DFA: fixed logic with parens

### DIFF
--- a/lib/DocumentsFieldArray/DocumentsFieldArray.js
+++ b/lib/DocumentsFieldArray/DocumentsFieldArray.js
@@ -57,7 +57,7 @@ class DocumentsFieldArray extends React.Component {
         }}
         deleteButtonTooltipText={(
           deleteButtonTooltipText ||
-            deleteBtnTooltipMsgId ? <FormattedMessage id={deleteBtnTooltipMsgId} values={{ index: i + 1 }} /> : undefined
+            (deleteBtnTooltipMsgId ? <FormattedMessage id={deleteBtnTooltipMsgId} values={{ index: i + 1 }} /> : undefined)
         )}
         header={<FormattedMessage id="stripes-erm-components.doc.title" values={{ number: i + 1 }} />}
         key={i}


### PR DESCRIPTION
The `true` case in the ternary expression was still firing when the first operand of the `||` was false. This shouldn't happen, we need the OR to short-circuit to `true`, so I added parens to make this explicit.

This handles ERM-669 in a more generic way since it maintains supported for the deprecated `deleteButtonTooltipText` prop