### PR TITLE
Use <FormatedNumber /> for displaying numbers, fixes ERM-747

### DIFF
--- a/lib/CustomPropertiesList/CustomPropertiesList.js
+++ b/lib/CustomPropertiesList/CustomPropertiesList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, FormattedNumber } from 'react-intl';
 import { Col, InfoPopover, KeyValue, Row } from '@folio/stripes/components';
 
 import Card from '../Card';
@@ -49,6 +49,12 @@ export default class CustomPropertiesList extends React.Component {
 
     if (typeof value === 'object' && value.label) {
       value = value.label;
+    }
+
+    if (customProperty.type === 'com.k_int.web.toolkit.custprops.types.CustomPropertyDecimal' && typeof value === 'number') {
+      value = (
+        <FormattedNumber value={value} />
+      );
     }
 
     const { internal, note: internalNote, publicNote } =

--- a/lib/CustomPropertiesList/tests/CustomPropertiesList-test.js
+++ b/lib/CustomPropertiesList/tests/CustomPropertiesList-test.js
@@ -126,7 +126,7 @@ const terms = [
   },
 ];
 
-describe('CustomPropertiesList', () => {
+describe.only('CustomPropertiesList', () => {
   const customPropertiesList = new CustomPropertiesListInteractor();
 
   beforeEach(async () => {
@@ -204,7 +204,7 @@ describe('CustomPropertiesList', () => {
   });
 
   it('renders the value as Yes under the fourth license term', () => {
-    expect(customPropertiesList.property(3).value).to.equal('Yes');
+    expect(customPropertiesList.property(3).value).to.equal(license?.customProperties?.copyPrint[0]?.value?.label);
   });
 
   it('renders the expected label under the fifth license term', () => {

--- a/lib/CustomPropertiesList/tests/CustomPropertiesList-test.js
+++ b/lib/CustomPropertiesList/tests/CustomPropertiesList-test.js
@@ -215,6 +215,6 @@ describe('CustomPropertiesList', () => {
   });
 
   it('renders expected decimal value under the fifth license term', () => {
-    expect(parseFloat(customPropertiesList.property(4).value)).to.equal(license?.customProperties?.decType[0]?.value);
+    expect(customPropertiesList.property(4).value).to.equal('13.33');
   });
 });

--- a/lib/CustomPropertiesList/tests/CustomPropertiesList-test.js
+++ b/lib/CustomPropertiesList/tests/CustomPropertiesList-test.js
@@ -20,6 +20,19 @@ const license = {
         value: 'testValue1',
       },
     ],
+    copyPrint: [
+      {
+        value: {
+          label: 'Yes',
+          value: 'yes'
+        }
+      }
+    ],
+    decType: [
+      {
+        value: '13.33'
+      }
+    ]
   },
 };
 
@@ -72,6 +85,44 @@ const terms = [
       'Can non-members of the library/instittuion use the resource when in the library',
     weight: 0,
     type: 'com.k_int.web.toolkit.custprops.types.CustomPropertyRefdata',
+  },
+  {
+    id: '4028808d6a2cf32b016a35ae1bf90025',
+    name: 'copyPrint',
+    primary: true,
+    category: {
+      id: '4028808d6a2cf32b016a35ae12150017',
+      desc: 'Yes/No/Other',
+      values: [
+        {
+          id: '4028808d6a2cf32b016a35ae1236001a',
+          value: 'yes',
+          label: 'Yes',
+        },
+        {
+          id: '4028808d6a2cf32b016a35ae12340018',
+          value: 'other',
+          label: 'Other (See Notes)',
+        },
+        {
+          id: '4028808d6a2cf32b016a35ae12360019',
+          value: 'no',
+          label: 'No',
+        },
+      ],
+    },
+    label: 'copy print',
+    weight: 0,
+    type: 'com.k_int.web.toolkit.custprops.types.CustomPropertyRefdata',
+  },
+  {
+    id: '4028808d6a2c2b016a35ae19010023',
+    name: 'decType',
+    primary: true,
+    label: 'Decimal type',
+    description: 'decimal type',
+    weight: 0,
+    type: 'com.k_int.web.toolkit.custprops.types.CustomPropertyDecimal',
   },
 ];
 
@@ -146,5 +197,21 @@ describe('CustomPropertiesList', () => {
 
   it('renders the value as Not set under the third license term', () => {
     expect(customPropertiesList.property(2).value).to.equal('Not set');
+  });
+
+  it('renders the expected label under the fourth license term', () => {
+    expect(customPropertiesList.property(3).label).to.equal(terms[3].label);
+  });
+
+  it('renders the value as Yes under the fourth license term', () => {
+    expect(customPropertiesList.property(3).value).to.equal('Yes');
+  });
+
+  it('renders the expected label under the fifth license term', () => {
+    expect(customPropertiesList.property(4).label).to.equal(terms[4].label);
+  });
+
+  it('renders expected decimal value under the fifth license term', () => {
+    expect(customPropertiesList.property(4).value).to.equal(license?.customProperties?.decType[0]?.value);
   });
 });

--- a/lib/CustomPropertiesList/tests/CustomPropertiesList-test.js
+++ b/lib/CustomPropertiesList/tests/CustomPropertiesList-test.js
@@ -126,7 +126,7 @@ const terms = [
   },
 ];
 
-describe.only('CustomPropertiesList', () => {
+describe('CustomPropertiesList', () => {
   const customPropertiesList = new CustomPropertiesListInteractor();
 
   beforeEach(async () => {

--- a/lib/CustomPropertiesList/tests/CustomPropertiesList-test.js
+++ b/lib/CustomPropertiesList/tests/CustomPropertiesList-test.js
@@ -30,7 +30,10 @@ const license = {
     ],
     decType: [
       {
-        value: '13.33'
+        type: {
+          type: 'com.k_int.web.toolkit.custprops.types.CustomPropertyDecimal'
+        },
+        value: '13.33',
       }
     ]
   },

--- a/lib/CustomPropertiesList/tests/CustomPropertiesList-test.js
+++ b/lib/CustomPropertiesList/tests/CustomPropertiesList-test.js
@@ -33,7 +33,7 @@ const license = {
         type: {
           type: 'com.k_int.web.toolkit.custprops.types.CustomPropertyDecimal'
         },
-        value: '13.33',
+        value: 13.33,
       }
     ]
   },
@@ -215,6 +215,6 @@ describe('CustomPropertiesList', () => {
   });
 
   it('renders expected decimal value under the fifth license term', () => {
-    expect(customPropertiesList.property(4).value).to.equal(license?.customProperties?.decType[0]?.value);
+    expect(parseFloat(customPropertiesList.property(4).value)).to.equal(license?.customProperties?.decType[0]?.value);
   });
 });

--- a/tests/helpers/Harness.js
+++ b/tests/helpers/Harness.js
@@ -7,6 +7,7 @@ import translations from '../../translations/stripes-erm-components/en';
 // mimics the StripesTranslationPlugin in @folio/stripes-core
 function prefixKeys(obj) {
   const res = {};
+  // eslint-disable-next-line no-unused-vars
   for (const key of Object.keys(obj)) {
     res[`stripes-erm-components.${key}`] = obj[key];
   }

--- a/tests/helpers/setupApplication.js
+++ b/tests/helpers/setupApplication.js
@@ -5,6 +5,7 @@ import translations from '../../translations/stripes-erm-components/en';
 
 function prefixKeys(obj) {
   const res = {};
+  // eslint-disable-next-line no-unused-vars
   for (const key of Object.keys(obj)) {
     res[`stripes-erm-components.${key}`] = obj[key];
   }


### PR DESCRIPTION
Use `FormattedNumber` to display numbers in the FOLIO locale

With this PR, if the browsers locale is set to `German`... inputs like `16,3` entered in the form are displayed as `16,3` in the view pane if the FOLIO locale is set to `German` and displayed as `16.3` if the locale is set to `English`