### PR TITLE
Add preventResourceRefresh utility function, refs ERM-852

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ export { default as customPropertyTypes } from './lib/customPropertyTypes';
 export { default as generateQueryParams } from './lib/generateQueryParams';
 export { default as getSASParams } from './lib/getSASParams';
 export { default as renderUserName } from './lib/renderUserName';
+export { default as preventResourceRefresh } from './lib/preventResourceRefresh';
 export {
   composeValidators,
   invalidNumber as invalidNumberValidator,

--- a/lib/CreateOrganizationModal/CreateOrganizationModal.js
+++ b/lib/CreateOrganizationModal/CreateOrganizationModal.js
@@ -19,6 +19,7 @@ class CreateOrganizationModal extends React.Component {
   constructor(props) {
     super(props);
 
+    // eslint-disable-next-line no-console
     console.warn('This component is deprecated and will be removed in the next major release of stripes-erm-components');
 
     this.connectedCreateOrganizationModalContainer = props.stripes.connect(CreateOrganizationModalContainer);

--- a/lib/preventResourceRefresh.js
+++ b/lib/preventResourceRefresh.js
@@ -8,14 +8,9 @@
    */
 
 const preventResourceRefresh = (resourceActionsMap) => (_, action) => {
-  let shouldPreventRefresh = true;
-  Object.entries(resourceActionsMap).some(([resourceName, actionTypes]) => {
-    if ((resourceName === action.meta.name) &&
-    actionTypes.some(actionType => action.meta?.originatingActionType.includes(actionType))) {
-      shouldPreventRefresh = false;
-    }
-  });
-  return shouldPreventRefresh;
+  return !Object.entries(resourceActionsMap).some(([resourceName, actionTypes]) => (
+    resourceName === action.meta.name &&
+    actionTypes.some(actionType => action.meta?.originatingActionType.includes(actionType))) === true);
 };
 
 export default preventResourceRefresh;

--- a/lib/preventResourceRefresh.js
+++ b/lib/preventResourceRefresh.js
@@ -1,0 +1,21 @@
+
+/* This function takes in a map of the resource and corresponding array of actionTypes and returns a false if
+   the resource thats executing the refresh needs to be prevented from refreshing
+
+   Eg: Assume you dont want to refresh the agreementLine resource because the agreement containing it has
+    been deleted, you could just pass a ```shouldRefresh: preventResourceRefresh({ 'agreement': ['DELETE'] })```
+    option to it and that would prevent it from refreshing
+   */
+
+const preventResourceRefresh = (resourceActionsMap) => (_, action) => {
+  let shouldPreventRefresh = true;
+  Object.entries(resourceActionsMap).some(([resourceName, actionTypes]) => {
+    if ((resourceName === action.meta.name) &&
+    actionTypes.some(actionType => action.meta?.originatingActionType.includes(actionType))) {
+      shouldPreventRefresh = false;
+    }
+  });
+  return shouldPreventRefresh;
+};
+
+export default preventResourceRefresh;


### PR DESCRIPTION
This function takes in a map of the resource and corresponding array of actionTypes and returns a false if the resource thats executing the refresh needs to be prevented from refreshing

 Eg: Assume you dont want to refresh the agreementLine resource because the agreement containing it has been deleted, you could just pass a 

`shouldRefresh: preventResourceRefresh({ 'agreement': ['DELETE'] })`
   
option to it and that would prevent it from refreshing