### PR TITLE
Tags: Don't throw errors

### DIFF
--- a/lib/Tags/Tags.js
+++ b/lib/Tags/Tags.js
@@ -22,6 +22,7 @@ class Tags extends React.Component {
     entities: {
       type: 'okapi',
       path: '!{link}',
+      throwErrors: false,
     },
   });
 


### PR DESCRIPTION
A record can be deleted via a mutator, which
then triggers a refetch of `entities` that then
generates a 404/500.