### PR TITLE
Release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Change history for stripes-erm-components
 
-## 3.0.0 IN PROGRESS
+## 3.0.0 2020-06-10
 * Disallow whitespace-only strings in `requiredValidator`. ERM-553
 * Upgrade to Stripes 4.0
 * Added ability to filter agreements and licenses by their custom properties. ERM-876
+* Added `withAsyncValidation` higher-order component. ERM-877
+* Added `preventResourceRefresh` helper function. ERM-852
+* Added `AlternativeNamesFieldArray` component. ERM-827 828
+* Added `DuplicateModal` component. ERM-814
+* Bumped the required node version to 10.
 
 ## 2.3.2 2020-05-27
 * Removed character limit on text custom properties. ERM-901

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "test": "stripes test karma",
@@ -56,6 +56,8 @@
     "react-router-dom": "^4.1.1"
   },
   "stripes": {
-    "actsAs": [""]
+    "actsAs": [
+      ""
+    ]
   }
 }


### PR DESCRIPTION
* Disallow whitespace-only strings in `requiredValidator`. ERM-553
* Upgrade to Stripes 4.0
* Added ability to filter agreements and licenses by their custom properties. ERM-876
* Added `withAsyncValidation` higher-order component. ERM-877
* Added `preventResourceRefresh` helper function. ERM-852
* Added `AlternativeNamesFieldArray` component. ERM-827 828
* Added `DuplicateModal` component. ERM-814
* Bumped the required node version to 10.
