### PR TITLE
ERM-1142 return null instead of '-' in TitleOnPlatformLink if there's…

### DIFF
--- a/lib/TitleOnPlatformLink/TitleOnPlatformLink.js
+++ b/lib/TitleOnPlatformLink/TitleOnPlatformLink.js
@@ -3,12 +3,11 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import {
   Icon,
-  NoValue,
   Tooltip,
 } from '@folio/stripes/components';
 
 const TitleOnPlatformLink = ({ id, platform, name, url }) => {
-  if (!platform && !url) return <NoValue />;
+  if (!platform && !url) return null;
 
   return (
     <div>


### PR DESCRIPTION
… no platform and url

`TitleOnPlatformLink` is only used in MCLs erm-wide.
The general aim is to remove the "-" from all MCLs. 