### PR TITLE
Increase size of credentials show hide button from 160px to 300px

### DIFF
--- a/lib/ViewOrganizationCard/ViewOrganizationCard.js
+++ b/lib/ViewOrganizationCard/ViewOrganizationCard.js
@@ -80,7 +80,7 @@ export default class ViewOrganizationCard extends React.Component {
             username: { min: 80, max: 100 },
             password: { min: 80, max: 100 },
             type: { min: 100, max: 150 },
-            showHideButton: 160,
+            showHideButton: 300,
           }}
           contentData={interfaces}
           formatter={{


### PR DESCRIPTION
Languages like German need this space, currently the right part
of the button and of the button label are out of the visible area
for German ("Anmeldeinformation anzeigen").