### PR TITLE
ERM-1749: On updating an existing organisation role the role value is updated but not the role label

### DIFF
--- a/lib/OrganizationsFieldArray/EditOrganizationCard.js
+++ b/lib/OrganizationsFieldArray/EditOrganizationCard.js
@@ -37,13 +37,6 @@ const EditOrganizationCard = ({
 }) => {
   let triggerButton = useRef(null);
   const [nameOfOrgNotLinked, setNOONL] = useState(null);
-
-  useEffect(() => {
-    if (!input?.value?.org?.orgsUuid && triggerButton.current) {
-      triggerButton.current.focus();
-    }
-  }, [input, triggerButton]);
-
   const [duplicateWarning, setDuplicateWarning] = useState(false);
 
   const { values } = useFormState();
@@ -115,7 +108,6 @@ const EditOrganizationCard = ({
             marginTop0
             renderTrigger={(pluggableRenderProps) => {
               triggerButton = pluggableRenderProps.buttonRef;
-
               const orgName = organization?.org?.name;
               const buttonProps = {
                 'aria-haspopup': 'true',
@@ -137,6 +129,7 @@ const EditOrganizationCard = ({
                     {({ ariaIds }) => (
                       <Button
                         aria-labelledby={ariaIds.text}
+                        autoFocus
                         data-test-org-link
                         {...buttonProps}
                       >
@@ -148,6 +141,7 @@ const EditOrganizationCard = ({
               }
               return (
                 <Button
+                  autoFocus
                   data-test-org-link
                   {...buttonProps}
                 >

--- a/lib/OrganizationsFieldArray/OrganizationsFieldArray.js
+++ b/lib/OrganizationsFieldArray/OrganizationsFieldArray.js
@@ -7,68 +7,70 @@ import { Button, Layout } from '@folio/stripes/components';
 import withKiwtFieldArray from '../withKiwtFieldArray';
 import EditOrganizationCard from './EditOrganizationCard';
 
-class OrganizationsFieldArray extends React.Component {
-  static propTypes = {
-    addOrganizationBtnLabel: PropTypes.node,
-    fields: PropTypes.object,
-    isEmptyMessage: PropTypes.node,
-    items: PropTypes.arrayOf(PropTypes.object),
-    name: PropTypes.string.isRequired,
-    onAddField: PropTypes.func.isRequired,
-    onDeleteField: PropTypes.func.isRequired,
-    onUpdateField: PropTypes.func.isRequired,
-    roles: PropTypes.arrayOf(PropTypes.object),
-  }
-
-  static defaultProps = {
-    addOrganizationBtnLabel: <FormattedMessage id="stripes-erm-components.organizations.addOrganization" />,
-    isEmptyMessage: <FormattedMessage id="stripes-erm-components.organizations.noOrganizations" />,
-  }
-
-  renderEmpty = () => (
+const OrganizationsFieldArray = ({
+  addOrganizationBtnLabel = <FormattedMessage id="stripes-erm-components.organizations.addOrganization" />,
+  fields,
+  isEmptyMessage = <FormattedMessage id="stripes-erm-components.organizations.noOrganizations" />,
+  items,
+  name,
+  onAddField,
+  onDeleteField,
+  onUpdateField,
+  roles
+}) => {
+  const renderEmpty = () => (
     <Layout className="padding-bottom-gutter" data-test-org-empty-message>
-      {this.props.isEmptyMessage}
+      {isEmptyMessage}
     </Layout>
-  )
+  );
 
-  renderOrganizations = (items) => (
+  const renderOrganizations = () => (
     items.map((organization, index) => {
       return (
         <Field
           key={index}
           component={EditOrganizationCard}
-          fields={this.props.fields}
-          id={`${this.props.name}-${index}`}
+          fields={fields}
+          id={`${name}-${index}`}
           index={index}
-          name={`${this.props.name}[${index}]`}
-          onDelete={() => this.props.onDeleteField(index, organization)}
-          onUpdate={this.props.onUpdateField}
+          name={`${name}[${index}]`}
+          onDelete={() => onDeleteField(index, organization)}
+          onUpdate={onUpdateField}
           organization={organization}
-          orgsKey={this.props.name}
-          roleValues={this.props.roles}
+          orgsKey={name}
+          roleValues={roles}
         />
       );
     })
-  )
+  );
 
-  render() {
-    const { items, onAddField } = this.props;
 
-    return (
-      <div data-test-org-fa>
-        <div>
-          {items.length ? this.renderOrganizations(items) : this.renderEmpty()}
-        </div>
-        <Button
-          data-test-org-fa-add-button
-          id="add-org-btn"
-          onClick={() => onAddField()}
-        >
-          {this.props.addOrganizationBtnLabel}
-        </Button>
+  return (
+    <div data-test-org-fa>
+      <div>
+        {items.length ? renderOrganizations() : renderEmpty()}
       </div>
-    );
-  }
-}
+      <Button
+        data-test-org-fa-add-button
+        id="add-org-btn"
+        onClick={() => onAddField()}
+      >
+        {addOrganizationBtnLabel}
+      </Button>
+    </div>
+  );
+};
+
+OrganizationsFieldArray.propTypes = {
+  addOrganizationBtnLabel: PropTypes.node,
+  fields: PropTypes.object,
+  isEmptyMessage: PropTypes.node,
+  items: PropTypes.arrayOf(PropTypes.object),
+  name: PropTypes.string.isRequired,
+  onAddField: PropTypes.func.isRequired,
+  onDeleteField: PropTypes.func.isRequired,
+  onUpdateField: PropTypes.func.isRequired,
+  roles: PropTypes.arrayOf(PropTypes.object),
+};
 
 export default withKiwtFieldArray(OrganizationsFieldArray);

--- a/lib/OrganizationsFieldArray/OrganizationsFieldArray.js
+++ b/lib/OrganizationsFieldArray/OrganizationsFieldArray.js
@@ -24,6 +24,7 @@ const OrganizationsFieldArray = ({
     </Layout>
   );
 
+  const roleValues = roles.map(role => ({ value: role.id, label: role.label }));
   const renderOrganizations = () => (
     items.map((organization, index) => {
       return (
@@ -38,7 +39,7 @@ const OrganizationsFieldArray = ({
           onUpdate={onUpdateField}
           organization={organization}
           orgsKey={name}
-          roleValues={roles}
+          roleValues={roleValues}
         />
       );
     })

--- a/lib/OrganizationsFieldArray/RolesFieldArray.js
+++ b/lib/OrganizationsFieldArray/RolesFieldArray.js
@@ -24,14 +24,14 @@ const RolesFieldArray = ({
   const [rolesInUse, setRolesInUse] = useState([]);
 
   useEffect(() => {
-    setRolesInUse(items.map(i => i?.role?.value).filter(x => !!x));
+    setRolesInUse(items.map(i => i?.role?.id).filter(x => !!x));
   }, [items]);
 
   const renderRoles = () => (
     items.map((item, index) => {
       // Construct roleValues per item
       // Allow either the currently set roleValue OR any that are not set elsewhere
-      const dataOptions = roleValues.filter(rv => !rolesInUse.includes(rv.value) || rv.value === item.role?.value);
+      const dataOptions = roleValues.filter(rv => !rolesInUse.includes(rv.value) || rv.value === item.role?.id);
       return (
         <Row key={index}>
           <Col md={4} xs={12}>

--- a/lib/OrganizationsFieldArray/RolesFieldArray.js
+++ b/lib/OrganizationsFieldArray/RolesFieldArray.js
@@ -42,7 +42,7 @@ const RolesFieldArray = ({
               component={Select}
               dataOptions={dataOptions}
               index={index}
-              name={`${name}[${index}].role.value`}
+              name={`${name}[${index}].role.id`}
               placeholder=" "
               validate={required}
             />

--- a/lib/OrganizationsFieldArray/tests/OrganizationsFieldArray-test.js
+++ b/lib/OrganizationsFieldArray/tests/OrganizationsFieldArray-test.js
@@ -47,6 +47,10 @@ const roles = [
   }
 ];
 
+const getIdFromValue = (value) => {
+  return roles.find(r => r.value === value)?.id || '';
+};
+
 const addOrganizationBtnLabel = 'Add an organization to get started';
 const isEmptyMessage = 'No Organizations added';
 
@@ -128,7 +132,7 @@ describe('OrganizationsFieldArray', () => {
       });
 
       it('sets the role value', () => {
-        expect(interactor.roles(0).roleValue).to.equal('content_provider');
+        expect(interactor.roles(0).roleValue).to.equal(getIdFromValue('content_provider'));
       });
 
       it('has a role field count of 1', () => {


### PR DESCRIPTION
Refactored component to functional
Tweaked form submission to use `id` instead of `value`
Fixed hungry focus bug (When no Org selected, entering details in other fields would be cut off by focus returning to link button)