### PR TITLE
Fix two prop-types errors

### DIFF
--- a/lib/InternalContactSelection/InternalContactSelectionDisplay.js
+++ b/lib/InternalContactSelection/InternalContactSelectionDisplay.js
@@ -44,7 +44,7 @@ export default class InternalContactSelectionDisplay extends React.Component {
             onFilter={(searchString, dataOptions) => {
               return dataOptions.filter(({ label }) => label.toLowerCase().indexOf(searchString.toLowerCase()) >= 0);
             }}
-            placeholder={placeholder}
+            placeholder={typeof placeholder === 'string' ? placeholder : placeholder[0]}
             value={value}
           />
         )}

--- a/lib/OrganizationSelection/OrganizationSelectionDisplay.js
+++ b/lib/OrganizationSelection/OrganizationSelectionDisplay.js
@@ -43,7 +43,7 @@ export default class OrganizationSelectionDisplay extends React.Component {
             id={id}
             onChange={onChange}
             onFilter={onFilter}
-            placeholder={placeholder}
+            placeholder={typeof placeholder === 'string' ? placeholder : placeholder[0]}
             value={value}
           />
         )}


### PR DESCRIPTION
In both cases, the problem is that due to recent changes in how translations are handled, the translation passed to the render-function content of `<FormattedMessage>` can sometimes be an array of a single string, rather than just a string. We allow for this case by checking the type of passed translation.