### PR TITLE
ERM-1897 upgrade react-intl-safe-html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 6.1.0 In progress
 
+* Upgrade `@folio/react-intl-safe-html` for compatibility with `@folio/stripes` `v7`. ERM-1897
+
 ## 6.0.0 2021-10-06
 * Fixed bug with error on saving license/agreement if a change in made to the visibility (internal) flag of a primary property without populating it. ERM-1770 ERM-1771
 * Upgrade to Stripes v7.

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-router-dom": "^5.2.0"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^2.0.0",
+    "@folio/react-intl-safe-html": "^3.1.0",
     "final-form": "^4.18.4",
     "final-form-arrays": "^3.0.1",
     "lodash": "^4.17.4",


### PR DESCRIPTION
Upgrade `@folio/react-intl-safe-html` for compatibility with
`@folio/stripes` `v7` (react 17, react-intl 5).

Refs [ERM-1897](https://issues.folio.org/browse/ERM-1897), [STRIPES-769](https://issues.folio.org/browse/STRIPES-769)