### PR TITLE
feat: useBatchedFetch Namespacing

### DIFF
--- a/lib/hooks/useBatchedFetch.js
+++ b/lib/hooks/useBatchedFetch.js
@@ -10,6 +10,7 @@ const useBatchedFetch = ({
   batchParams = {},
   batchLimit = DEFAULT_BATCH_LIMIT,
   batchSize,
+  nsArray, // An array to replace the default namespaceArray defined below
   path,
 }) => {
   const ky = useOkapiKy();
@@ -26,6 +27,8 @@ const useBatchedFetch = ({
 
   const safeBatchSize = Math.min(batchSize, MAX_BATCH_SIZE);
 
+  const namespaceArray = nsArray ?? [path, paramsArray, 'stripes-erm-components', 'useBatchedFetch'];
+
   const {
     infiniteQueryObject: {
       fetchNextPage,
@@ -35,7 +38,7 @@ const useBatchedFetch = ({
     results = [],
     total = 0
   } = useInfiniteFetch(
-    [path, paramsArray, 'stripes-erm-components', 'useBatchedFetch'],
+    namespaceArray,
     ({ pageParam = 0 }) => {
       const params = [...paramsArray, `offset=${pageParam}`];
       return ky.get(`${path}?${params?.join('&')}`).json();


### PR DESCRIPTION
Allow useBatchedFetch to accept a nsArray prop to use in place of the namespace array default it provides. This allows us to choose a convention as we call the hook.

ERM-2225, ERM-2227