### PR TITLE
ERM-2366: Core documents for a License shouldn't display a category

### DIFF
--- a/lib/DocumentCard/DocumentCard.js
+++ b/lib/DocumentCard/DocumentCard.js
@@ -17,6 +17,7 @@ const DocumentCard = ({
   } = {},
   fileUpload,
   hasDownloadPerm = false,
+  hideCategory = false,
   location,
   name,
   note,
@@ -82,6 +83,18 @@ const DocumentCard = ({
     return null;
   };
 
+  const categorySection = () => {
+    if (!hideCategory) {
+      return (
+        <KeyValue label={<FormattedMessage id="stripes-erm-components.doc.category" />}>
+          {category ? <div data-test-doc-category>{category}</div> : null}
+        </KeyValue>
+      );
+    }
+
+    return null;
+  };
+
   return (
     <Card
       data-test-doc={name}
@@ -98,12 +111,7 @@ const DocumentCard = ({
           </KeyValue>
         </Col>
         <Col xs={4}>
-          <KeyValue label={<FormattedMessage id="stripes-erm-components.doc.category" />}>
-            {category ?
-              <div data-test-doc-category>{category}</div> :
-              <NoValue />
-            }
-          </KeyValue>
+          {categorySection()}
         </Col>
       </Row>
       <MultiColumnList
@@ -133,6 +141,7 @@ DocumentCard.propTypes = {
     name: PropTypes.string,
   }),
   hasDownloadPerm: PropTypes.bool,
+  hideCategory: PropTypes.bool,
   location: PropTypes.string,
   name: PropTypes.string.isRequired,
   note: PropTypes.string,

--- a/lib/DocumentCard/DocumentCard.test.js
+++ b/lib/DocumentCard/DocumentCard.test.js
@@ -29,60 +29,83 @@ const doc = {
 
 let renderComponent;
 describe('DocumentCard', () => {
-  beforeEach(() => {
-    renderComponent = renderWithIntl(
-      <Router>
-        <DocumentCard
-          key={doc.id}
-          hasDownloadPerm
-          onDownloadFile={onDownloadFile}
-          {...doc}
-        />
-      </Router>,
-      translationsProperties
-    );
+  describe('DocumentCard', () => {
+    beforeEach(() => {
+      renderComponent = renderWithIntl(
+        <Router>
+          <DocumentCard
+            key={doc.id}
+            hasDownloadPerm
+            onDownloadFile={onDownloadFile}
+            {...doc}
+          />
+        </Router>,
+        translationsProperties
+      );
+    });
+
+    test('renders the documents name as headline', () => {
+      const { getByText } = renderComponent;
+      expect(getByText('A test document attachment')).toBeInTheDocument();
+    });
+
+    test('renders the expected note', async () => {
+      await KeyValue('Note').has({ value: 'This is a test document attachment' });
+    });
+
+    test('renders the expected category', async () => {
+      await KeyValue('Category').has({ value: 'Misc' });
+    });
+
+    test('renders the documents locations MCL', async () => {
+      await MultiColumnList('documents-locations').exists();
+    });
+
+    test('renders expected type and reference mcl cells', async () => {
+      Promise.all([
+        await MultiColumnListCell({ row: 0, columnIndex: 0 }).has({ content: 'Physical location' }),
+        await MultiColumnListCell({ row: 0, columnIndex: 1 }).has({ content: 'office shelf' }),
+        await MultiColumnListCell({ row: 1, columnIndex: 0 }).has({ content: 'URL' }),
+        await MultiColumnListCell({ row: 1, columnIndex: 1 }).has({ content: 'https://a.b.c/e' }),
+        await MultiColumnListCell({ row: 2, columnIndex: 0 }).has({ content: 'File' }),
+        await MultiColumnListCell({ row: 2, columnIndex: 1 }).has({ content: 'file.pdf' }),
+      ]);
+    });
+
+    test('renders a link with the URL', async () => {
+      const { getByRole } = renderComponent;
+      expect(getByRole('link', { name: 'https://a.b.c/e' })).toBeInTheDocument();
+    });
+
+    test('renders a link with the File', async () => {
+      const { getByRole } = renderComponent;
+      expect(getByRole('link', { name: 'file.pdf' })).toBeInTheDocument();
+    });
+
+    test('clicking the file download link', async () => {
+      await Link('file.pdf').click();
+      expect(onDownloadFile).toHaveBeenCalled();
+    });
   });
 
-  test('renders the documents name as headline', () => {
-    const { getByText } = renderComponent;
-    expect(getByText('A test document attachment')).toBeInTheDocument();
-  });
+  describe('DocumentCard with hideCategory', () => {
+    beforeEach(() => {
+      renderComponent = renderWithIntl(
+        <Router>
+          <DocumentCard
+            key={doc.id}
+            hasDownloadPerm
+            hideCategory
+            onDownloadFile={onDownloadFile}
+            {...doc}
+          />
+        </Router>,
+        translationsProperties
+      );
+    });
 
-  test('renders the expected note', async () => {
-    await KeyValue('Note').has({ value: 'This is a test document attachment' });
-  });
-
-  test('renders the expected category', async () => {
-    await KeyValue('Category').has({ value: 'Misc' });
-  });
-
-  test('renders the documents locations MCL', async () => {
-    await MultiColumnList('documents-locations').exists();
-  });
-
-  test('renders expected type and reference mcl cells', async () => {
-    Promise.all([
-      await MultiColumnListCell({ row: 0, columnIndex: 0 }).has({ content: 'Physical location' }),
-      await MultiColumnListCell({ row: 0, columnIndex: 1 }).has({ content: 'office shelf' }),
-      await MultiColumnListCell({ row: 1, columnIndex: 0 }).has({ content: 'URL' }),
-      await MultiColumnListCell({ row: 1, columnIndex: 1 }).has({ content: 'https://a.b.c/e' }),
-      await MultiColumnListCell({ row: 2, columnIndex: 0 }).has({ content: 'File' }),
-      await MultiColumnListCell({ row: 2, columnIndex: 1 }).has({ content: 'file.pdf' }),
-    ]);
-  });
-
-  test('renders a link with the URL', async () => {
-    const { getByRole } = renderComponent;
-    expect(getByRole('link', { name: 'https://a.b.c/e' })).toBeInTheDocument();
-  });
-
-  test('renders a link with the File', async () => {
-    const { getByRole } = renderComponent;
-    expect(getByRole('link', { name: 'file.pdf' })).toBeInTheDocument();
-  });
-
-  test('clicking the file download link', async () => {
-    await Link('file.pdf').click();
-    expect(onDownloadFile).toHaveBeenCalled();
+    test('does not render category', async () => {
+      await KeyValue('Category').absent();
+    });
   });
 });


### PR DESCRIPTION
feat: DocumentCard hideCategory

Added hideCategory prop to DocumentCard to enable implementors to hide that keyValue. Tests amended and linting

ERM-2366