### PR TITLE
fix: hasInterface

### DIFF
--- a/lib/hooks/useUsers.js
+++ b/lib/hooks/useUsers.js
@@ -4,7 +4,7 @@ import { useOkapiKy, useStripes } from '@folio/stripes/core';
 
 const useUsers = (userIds = []) => {
   const stripes = useStripes();
-  const query = userIds.map(uid => `id=${uid}`).join('or');
+  const query = userIds.map(uid => `id=${uid}`).join('or') ?? [];
 
   const ky = useOkapiKy();
   const queryObject = useQuery(
@@ -13,7 +13,10 @@ const useUsers = (userIds = []) => {
     {
       enabled: (
         !!query?.length &&
-        stripes.hasInterface('users', '15.0') &&
+        (
+          !!stripes.hasInterface('users', '15.0') ||
+          !!stripes.hasInterface('users', '16.0')
+        ) &&
         stripes.hasPerm('users.collection.get')
       )
     }


### PR DESCRIPTION
Fixed issue where hasInterface returns an unexpected value (hasInterface returns the interface value in the system if the condition is met, or `0` otherwise. This forces us us to use the operator `!!` to get a boolean value out of it.

In addition, ERM has made a point of supporting both users interface 15 AND interface 16, and the hasInterface block has been expanded to reflect this.

ERM-2390