### PR TITLE
Revert "ERM-2395: Remove @folio/stripes-testing as direct dependency of stripes-erm-components"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Change history for stripes-erm-components
 
 ## 7.1.0 In progress
-* ERM-2395 Remove @folio/stripes-testing as direct dependency of stripes-erm-components
 
 ## 7.0.0 2022-10-26
 * ERM-2390 Licenses fails to add internal contact

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@folio/eslint-config-stripes": "^6.1.0",
     "@folio/stripes": "^7.3.1",
     "@folio/stripes-cli": "^2.6.1",
-    "@folio/stripes-testing": "^4.3.1",
+    "@folio/stripes-testing": "^4.2.0",
     "@formatjs/cli": "^4.2.31",
     "@interactors/html": "^1.0.0-rc1.2",
     "@testing-library/dom": "^8.16.0",
@@ -78,6 +78,7 @@
     "typescript": "^2.8.0"
   },
   "dependencies": {
+    "@folio/stripes-testing": "^4.3.1",
     "@k-int/stripes-kint-components": "^3.0.0",
     "@testing-library/react": "^12.1.5",
     "final-form": "^4.18.4",


### PR DESCRIPTION
Reverts folio-org/stripes-erm-components#563. PR #563 solved a small problem by removing some test-related dependencies which have unsatisfied peer-dep warnings when built at the platform-level, but doing that created a much worse problem that actually resulted in a build failure at the platform level because some public test infrastructure relied on those dependencies. 

It's no good having a noisy platform build, but a having a broken platform build is (of course) even worse. And since treeshaking is doing its job for us and keeping those test-related deps out of the final bundle, it's clear the prudent thing is to just go back to how things were pre-563 and publish yet another patch release. 

Sorry for the churn.