### PR TITLE
Revert "build: Remove @folio/stripes-testing as direct dependency of …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change history for stripes-erm-components
 
+## 7.0.2 2022-11-01
+* Revert ERM-2395 for Nolana
 ## 7.0.1 2022-10-26
 * ERM-2395 Remove @folio/stripes-testing as direct dependency of stripes-erm-components
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-erm-components",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Component library for Stripes ERM applications",
   "sideEffects": [
     "*.css"
@@ -34,7 +34,7 @@
     "@folio/eslint-config-stripes": "^6.1.0",
     "@folio/stripes": "^7.3.1",
     "@folio/stripes-cli": "^2.6.1",
-    "@folio/stripes-testing": "^4.3.1",
+    "@folio/stripes-testing": "^4.2.0",
     "@formatjs/cli": "^4.2.31",
     "@interactors/html": "^1.0.0-rc1.2",
     "@testing-library/dom": "^8.16.0",
@@ -78,6 +78,7 @@
     "typescript": "^2.8.0"
   },
   "dependencies": {
+    "@folio/stripes-testing": "^4.3.1",
     "@k-int/stripes-kint-components": "^3.0.0",
     "@testing-library/react": "^12.1.5",
     "final-form": "^4.18.4",


### PR DESCRIPTION
…stripes-erm-components (#563)"

This reverts commit 724012567d906c3062f17393acaf7287254ec76f.