### PR TITLE
ERM-2616 Upgrade react-redux to v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * LoadingPane
   * withAsyncValidation
   * withKiwtFieldArray
+* Upgrade `react-redux` to `v8`. Refs ERM-2616.
+
 ## 7.0.0 2022-10-26
 * ERM-2390 Licenses fails to add internal contact
 * ERM-2366 Core documents for a License shouldn't display a category

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.1",
     "react-query": "^3.6.0",
-    "react-redux": "^7.0.0",
+    "react-redux": "^8.0.5",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.0",
@@ -95,6 +95,7 @@
     "react": "^17.0.2",
     "react-intl": "^5.8.1",
     "react-query": "^3.9.0",
+    "react-redux": "^8.0.5",
     "react-router-dom": "^5.2.0"
   },
   "stripes": {


### PR DESCRIPTION
- Refs https://issues.folio.org/browse/ERM-2616.
- Upgrade will be happening across all of Stripes framework and modules that reference react-redux.
- v7 to v8 is a very harmless upgrade and is only considered breaking since they removed a few rarely used functions (which I confirmed we don't use). See https://github.com/reduxjs/react-redux/releases/tag/v8.0.0 for more details.