### PR TITLE
ERM-2547: On agreement and license user details do not display when more than one user linked to agreement/license as Internal contact

### DIFF
--- a/lib/hooks/useUsers.js
+++ b/lib/hooks/useUsers.js
@@ -4,7 +4,7 @@ import { useOkapiKy, useStripes } from '@folio/stripes/core';
 
 const useUsers = (userIds = []) => {
   const stripes = useStripes();
-  const query = userIds.map(uid => `id=${uid}`).join('or') ?? [];
+  const query = userIds.map(uid => `id=${uid}`).join(' or ') ?? [];
 
   const ky = useOkapiKy();
   const queryObject = useQuery(


### PR DESCRIPTION
fix: users request

User details were not being correctly fetched due to an error in the joining logic between ids in the request. This has been rectified

ERM-2547