### PR TITLE
ERM-2474: Local KB admin: Info log export populates title element in additionalInfo with non-relevant data

### DIFF
--- a/lib/LogsList/LogsList.js
+++ b/lib/LogsList/LogsList.js
@@ -17,13 +17,14 @@ export default class LogsList extends React.Component {
 
     resultsFormatter = {
       recordDescriptor: ({ additionalInfo = {} }) => {
-        const { packageSource, packageReference, rowNumber, recordNumber } = additionalInfo;
+        const { packageSource, packageReference, rowNumber, recordNumber, title } = additionalInfo;
         return (
           <div>
             {packageSource ? <FormattedMessage id="stripes-erm-components.packageSource" tagName="div" values={{ packageSource }} /> : null}
             {packageReference ? <FormattedMessage id="stripes-erm-components.packageReference" tagName="div" values={{ packageReference }} /> : null}
             {rowNumber ? <FormattedMessage id="stripes-erm-components.rowNumber" tagName="div" values={{ rowNumber }} /> : null}
             {recordNumber ? <FormattedMessage id="stripes-erm-components.recordNumber" tagName="div" values={{ recordNumber }} /> : null}
+            {title ? <FormattedMessage id="stripes-erm-components.logs.title" tagName="div" values={{ title }} /> : null}
           </div>
         );
       }

--- a/translations/stripes-erm-components/en.json
+++ b/translations/stripes-erm-components/en.json
@@ -30,6 +30,7 @@
   "packageReference": "Package reference: {packageReference}",
   "rowNumber": "Row number: {rowNumber}",
   "recordNumber": "Record number: {recordNumber}",
+  "logs.title": "Title: {title}",
   "contacts.addContact": "Add internal contact",
   "contacts.contactIndex": "Internal contact {index}",
   "contacts.email": "Email address",


### PR DESCRIPTION
feat: LogInfo title

Added title MDC display to LogsList so that when title data is available it can be seen clearly in the frontend

ERM-2474