### PR TITLE
ERM-2929: InternalContactSelection gets stuck in fetch loop

### DIFF
--- a/lib/InternalContactSelection/InternalContactSelection.js
+++ b/lib/InternalContactSelection/InternalContactSelection.js
@@ -17,6 +17,10 @@ const InternalContactSelection = ({
     results: contacts,
     isLoading: areContactsLoading
   } = useBatchedFetch({
+    // Ensure we get a uniquely ordered list
+    batchParams: {
+      sort: [{ path: 'id' }]
+    },
     path
   });
 

--- a/lib/hooks/useBatchedFetch.js
+++ b/lib/hooks/useBatchedFetch.js
@@ -52,9 +52,16 @@ const useBatchedFetch = ({
       results?.length !== total &&
       results?.length < batchLimit
     ) {
-      fetchNextPage({ pageParam: (pageParams[-1] ?? 0) + safeBatchSize });
+      fetchNextPage({ pageParam: (pageParams?.at(-1) ?? 0) + safeBatchSize });
     }
-  });
+  }, [
+    batchLimit,
+    fetchNextPage,
+    pageParams,
+    results?.length,
+    safeBatchSize,
+    total
+  ]);
 
   return {
     results,


### PR DESCRIPTION
fix: ERM-2929

Syntax error in useBatchedFetch grabbing final array element using [-1] instead of .at(-1)

Also ensure unique sort order for those contacts

ERM-2929