### PR TITLE
ERM-2929 dedupe contacts by user before iterating

### DIFF
--- a/lib/InternalContactSelection/InternalContactSelection.js
+++ b/lib/InternalContactSelection/InternalContactSelection.js
@@ -24,7 +24,7 @@ const InternalContactSelection = ({
     path
   });
 
-  const contactsUserIds = useMemo(() => contacts?.filter(c => c.user)?.map(c => c.user) ?? [], [contacts]);
+  const contactsUserIds = useMemo(() => uniqBy(contacts, 'user')?.filter(c => c.user)?.map(c => c.user) ?? [], [contacts]);
 
   // Fetch all users relevant to internal contacts
   const { users, isLoading: areUsersLoading } = useChunkedUsers(contactsUserIds);


### PR DESCRIPTION
Dedupe contacts by user before fetching related users, just as the contact list is deduped by user when iterating through it inside `useEffect`. Without this change in place, the JS console fills with warnings:

```
Warning: Maximum update depth exceeded. This can happen when a
component calls setState inside useEffect, but useEffect either
doesn't have a dependency array, or one of the dependencies
changes on every render.
    at InternalContactSelection.js:49
```

TBH, I don't entirely understand why this fix works, but it allows the `users` value to stabilize, thus preventing the dependencies from changing on every render.

Refs [ERM-2929](https://issues.folio.org/browse/ERM-2929)