### PR TITLE
ERM-2938 return undefined in useEffect's setup function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 8.1.0 In progress
 * ERM-2064 Move large file upload warning in document to a toast message
+* ERM-2938 Return undefined, not null, from functions passed to useEffect
 
 ## 8.0.0 2023-02-22
 * ERM-2634 If an agreement or license has >10 contacts they do not all display correctly

--- a/lib/InternalContactsFieldArray/InternalContactsFieldArray.js
+++ b/lib/InternalContactsFieldArray/InternalContactsFieldArray.js
@@ -32,7 +32,6 @@ const InternalContactsFieldArray = ({
       propUsers.forEach(u => { outputUsers[u.id] = u; });
       setUsers(outputUsers);
     }
-    return null;
   }, [propUsers, users]);
 
   // istanbul ignore next


### PR DESCRIPTION
The function passed to `useEffect` must return a cleanup function or undefined. Presently, it returns null, causing an unrecoverable error under react v18:
```
Warning: useEffect must not return anything besides a function,
which is used for clean-up. You returned null. If your effect
does not require clean up, return undefined (or nothing).
```

Refs [ERM-2938](https://issues.folio.org/browse/ERM-2938)