### PR TITLE
ERM-2967: Use useChunkedCQLFetch consistently across ERM

### DIFF
--- a/lib/hooks/useChunkedCQLFetch.js
+++ b/lib/hooks/useChunkedCQLFetch.js
@@ -2,20 +2,32 @@ import { useCallback, useEffect, useState } from 'react';
 import { useQueries } from 'react-query';
 
 import { chunk } from 'lodash';
-
 import { useOkapiKy } from '@folio/stripes/core';
 
 // When fetching from a potentially large list of items,
 // make sure to chunk the request to avoid hitting limits.
+
+// Only defining defaults to ward of "magic number" sonarlint rule -.-
+const CONCURRENT_REQUESTS_DEFAULT = 5;
+const STEP_SIZE_DEFAULT = 60;
+
+// CONCURRENT_REQUESTS and STEP_SIZE can be tweaked here, but implementor beware
+// They are formatted as if constants to discourage this
 const useChunkedCQLFetch = ({
+  CONCURRENT_REQUESTS = CONCURRENT_REQUESTS_DEFAULT, // Number of requests to make concurrently
   endpoint, // endpoint to hit to fetch items
-  ids, // List of ids to fetch
-  reduceFunction // Function to reduce fetched objects at the end into single array
+  ids: passedIds, // List of ids to fetch
+  queryOptions: passedQueryOptions = {}, // Options to pass to each query
+  reduceFunction, // Function to reduce fetched objects at the end into single array
+  STEP_SIZE = STEP_SIZE_DEFAULT // Number of ids fetch per request
 }) => {
   const ky = useOkapiKy();
 
-  const CONCURRENT_REQUESTS = 5; // Number of requests to make concurrently
-  const STEP_SIZE = 60; // Number of ids to request for per concurrent request
+  // Destructure passed query options to grab enabled
+  const { enabled: queryEnabled = true, ...queryOptions } = passedQueryOptions;
+
+  // Deduplicate incoming ID list
+  const ids = passedIds.filter((id, ind, arr) => arr.indexOf(id) === ind);
 
   const chunkedItems = chunk(ids, STEP_SIZE);
   // chunkedItems will be an array of arrays of size CONCURRENT_REQUESTS * STEP_SIZE
@@ -28,17 +40,18 @@ const useChunkedCQLFetch = ({
   const getQueryArray = useCallback(() => {
     const queryArray = [];
     chunkedItems.forEach((chunkedItem, chunkedItemIndex) => {
-      const query = chunkedItem.map(item => `id==${item}`).join(' or ');
+      const query = `id==(${chunkedItem.join(' or ')})`;
       queryArray.push({
         queryKey: ['ERM', endpoint, chunkedItem],
         queryFn: () => ky.get(`${endpoint}?limit=1000&query=${query}`).json(),
         // Only enable once the previous slice has all been fetched
-        enabled: chunkedItemIndex < CONCURRENT_REQUESTS
+        enabled: queryEnabled && chunkedItemIndex < CONCURRENT_REQUESTS,
+        ...queryOptions
       });
     });
 
     return queryArray;
-  }, [chunkedItems, endpoint, ky]);
+  }, [CONCURRENT_REQUESTS, chunkedItems, endpoint, ky, queryEnabled, queryOptions]);
 
   const itemQueries = useQueries(getQueryArray());
 
@@ -60,7 +73,7 @@ const useChunkedCQLFetch = ({
         });
       }
     });
-  }, [itemQueries]);
+  }, [CONCURRENT_REQUESTS, itemQueries]);
 
   // Keep easy track of whether this hook is all loaded or not
   // (This slightly flattens the "isLoading/isFetched" distinction, but it's an ease of use prop)

--- a/lib/hooks/useChunkedUsers.js
+++ b/lib/hooks/useChunkedUsers.js
@@ -2,7 +2,7 @@ import useChunkedCQLFetch from './useChunkedCQLFetch';
 
 // When fetching from a potentially large list of users,
 // make sure to chunk the request to avoid hitting limits.
-const useChunkedUsers = (userIds) => {
+const useChunkedUsers = (userIds, queryOptions = {}) => {
   const {
     itemQueries: userQueries,
     isLoading,
@@ -14,7 +14,8 @@ const useChunkedUsers = (userIds) => {
       uq.reduce((acc, curr) => {
         return [...acc, ...(curr?.data?.users ?? [])];
       }, [])
-    )
+    ),
+    queryOptions
   });
 
   return {


### PR DESCRIPTION
feat: useChunkedCQLFetch imrpovements

Improvements to useChunkedCQLFetch to hopefully allow it to be used generically across ERM. If it satisfies all our use cases then it is ready to be moved to stripes-core

Improvements:
- Built in id list deduplication
- Swap to slightly more efficient (lengthwise) id query
- Ability to pass in queryOptions to useQueries
- Ability to tweak CONCURRENT_REQUESTS and STEP_SIZE
  - These have been left in the form of constants to discourage that

refs STCOR-730, ERM-2967