### PR TITLE
feat: useParallelBatchFetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 8.1.0 In progress
 * ERM-2064 Move large file upload warning in document to a toast message
 * ERM-2938 Return undefined, not null, from functions passed to useEffect
+* Added useParallelBatchFetch hook
+  * For batch fetching KIWT resources
+  * API more in line with useChunkedCQLFetch -- and in parallel
 
 ## 8.0.0 2023-02-22
 * ERM-2634 If an agreement or license has >10 contacts they do not all display correctly

--- a/lib/hooks/index.js
+++ b/lib/hooks/index.js
@@ -13,3 +13,4 @@ export { default as useInterfaceCredentials } from './useInterfaceCredentials';
 export { default as useSingleFetchInterfaceCredentials } from './useSingleFetchInterfaceCredentials';
 export { default as useChunkedCQLFetch } from './useChunkedCQLFetch';
 export { default as useChunkedUsers } from './useChunkedUsers';
+export { default as useParallelBatchFetch } from './useParallelBatchFetch';

--- a/lib/hooks/useChunkedCQLFetch.js
+++ b/lib/hooks/useChunkedCQLFetch.js
@@ -4,8 +4,19 @@ import { useQueries } from 'react-query';
 import { chunk } from 'lodash';
 import { useOkapiKy } from '@folio/stripes/core';
 
-// When fetching from a potentially large list of items,
-// make sure to chunk the request to avoid hitting limits.
+/* When fetching from a potentially large list of items,
+ * make sure to chunk the request to avoid hitting limits.
+
+ * This is a contentious inclusion in stripes-core, as it encourages
+ * frontend joins rather than "proper" API design, and developers should
+ * be aware that this represents something of an antipattern. However, on
+ * occasion frontend joins are the most expedient and efficient ways of completing
+ * cross-module functionality, and so this hook aims to standardise the bulk
+ * fetching of resources from a CQL module.
+ *
+ * See slack thread https://folio-project.slack.com/archives/C210UCHQ9/p1688141053428329
+ * for more context.
+ */
 
 // Only defining defaults to ward of "magic number" sonarlint rule -.-
 const CONCURRENT_REQUESTS_DEFAULT = 5;
@@ -16,6 +27,7 @@ const STEP_SIZE_DEFAULT = 60;
 const useChunkedCQLFetch = ({
   CONCURRENT_REQUESTS = CONCURRENT_REQUESTS_DEFAULT, // Number of requests to make concurrently
   endpoint, // endpoint to hit to fetch items
+  generateQueryKey, // Passed function to allow customised query keys
   ids: passedIds, // List of ids to fetch
   queryOptions: passedQueryOptions = {}, // Options to pass to each query
   reduceFunction, // Function to reduce fetched objects at the end into single array
@@ -36,13 +48,25 @@ const useChunkedCQLFetch = ({
 
   const [isLoading, setIsLoading] = useState(ids?.length > 0);
 
+
   // Set up query array, and only enable the first CONCURRENT_REQUESTS requests
   const getQueryArray = useCallback(() => {
     const queryArray = [];
     chunkedItems.forEach((chunkedItem, chunkedItemIndex) => {
       const query = `id==(${chunkedItem.join(' or ')})`;
+      const queryKey = generateQueryKey ?
+        generateQueryKey({
+          CONCURRENT_REQUESTS,
+          chunkedItem,
+          chunkedItemIndex,
+          endpoint,
+          ids,
+          queryOptions,
+          STEP_SIZE
+        }) :
+        ['stripes-core', endpoint, chunkedItem];
       queryArray.push({
-        queryKey: ['ERM', endpoint, chunkedItem],
+        queryKey,
         queryFn: () => ky.get(`${endpoint}?limit=1000&query=${query}`).json(),
         // Only enable once the previous slice has all been fetched
         enabled: queryEnabled && chunkedItemIndex < CONCURRENT_REQUESTS,
@@ -51,7 +75,17 @@ const useChunkedCQLFetch = ({
     });
 
     return queryArray;
-  }, [CONCURRENT_REQUESTS, chunkedItems, endpoint, ky, queryEnabled, queryOptions]);
+  }, [
+    chunkedItems,
+    CONCURRENT_REQUESTS,
+    endpoint,
+    generateQueryKey,
+    ids,
+    ky,
+    queryEnabled,
+    queryOptions,
+    STEP_SIZE
+  ]);
 
   const itemQueries = useQueries(getQueryArray());
 

--- a/lib/hooks/useChunkedUsers.js
+++ b/lib/hooks/useChunkedUsers.js
@@ -10,12 +10,13 @@ const useChunkedUsers = (userIds, queryOptions = {}) => {
   } = useChunkedCQLFetch({
     ids: userIds,
     endpoint: 'users',
+    generateQueryKey: ({ chunkedItem, endpoint }) => (['ERM', endpoint, chunkedItem]),
     reduceFunction: (uq) => (
       uq.reduce((acc, curr) => {
         return [...acc, ...(curr?.data?.users ?? [])];
       }, [])
     ),
-    queryOptions
+    queryOptions,
   });
 
   return {

--- a/lib/hooks/useParallelBatchFetch.js
+++ b/lib/hooks/useParallelBatchFetch.js
@@ -1,0 +1,157 @@
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useQueries, useQuery } from 'react-query';
+
+import { chunk } from 'lodash';
+import { useOkapiKy } from '@folio/stripes/core';
+import { generateKiwtQueryParams } from '@k-int/stripes-kint-components';
+
+// A hook to do the same thing as batch fetching > 100 resources, but parallelising it.
+
+// Only defining defaults to ward of "magic number" sonarlint rule -.-
+const CONCURRENT_REQUESTS_DEFAULT = 5;
+const MAX_BATCH_SIZE = 100;
+const DEFAULT_BATCH_LIMIT = Infinity;
+
+// CONCURRENT_REQUESTS and BATCH_SIZE can be tweaked here, but implementor beware
+// They are formatted as if constants to discourage this
+const useParallelBatchFetch = ({
+  BATCH_LIMIT = DEFAULT_BATCH_LIMIT, // Number of resources to stop at, Infinity by default but can be set to a limit
+  batchParams = {}, // Params object of the shape accepted by generateKiwtQueryParams
+  BATCH_SIZE = MAX_BATCH_SIZE, // Number of resources to fetch per batch
+  CONCURRENT_REQUESTS = CONCURRENT_REQUESTS_DEFAULT, // Number of requests to make concurrently
+  endpoint, // endpoint to hit to fetch items
+  generateQueryKey, // Passed function to allow customised query keys
+  queryOptions: passedQueryOptions = {}, // Options to pass to each query
+}) => {
+  const ky = useOkapiKy();
+  const SAFE_BATCH_SIZE = Math.min(BATCH_SIZE, MAX_BATCH_SIZE);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Destructure passed query options to grab enabled
+  const { enabled: queryEnabled = true, ...queryOptions } = passedQueryOptions;
+
+  const paramsArray = useMemo(() => (
+    generateKiwtQueryParams(
+      {
+        ...batchParams,
+        perPage: SAFE_BATCH_SIZE,
+        stats: true
+      },
+      {}
+    )
+  ), [batchParams, SAFE_BATCH_SIZE]);
+
+  const getDefaultNSArray = useCallback((offset) => ['ERM', endpoint, offset, paramsArray, 'useChunkedBatchedFetch'], [endpoint, paramsArray]);
+  const namespaceArray = generateQueryKey ? generateQueryKey({
+    CONCURRENT_REQUESTS,
+    BATCH_LIMIT,
+    SAFE_BATCH_SIZE,
+    batchParams,
+    endpoint,
+    offset: 0,
+    paramsArray,
+    passedQueryOptions,
+  }) : getDefaultNSArray(0);
+
+
+  // Firstly fetch page 1 to get information about totals
+  const firstFetchResult = useQuery(
+    namespaceArray,
+    () => ky.get(`${endpoint}?${[...paramsArray, 'offset=0']?.join('&')}`).json(),
+    passedQueryOptions
+  );
+
+  // WAIT for initial fetch to conclude before setting up queryArray
+  // Set up query array, and only enable the first CONCURRENT_REQUESTS requests
+  const getQueryArray = useCallback(() => {
+    if (!firstFetchResult?.isFetched) {
+      return [];
+    }
+
+    const totalRecords = firstFetchResult?.data?.total ?? 0;
+    const recordsToFetch = Math.min(totalRecords, BATCH_LIMIT);
+    // Have already fetched page 1
+
+    const queryArray = [];
+    // Offset will be i * SAFE_BATCH_SIZE
+    for (let offset = SAFE_BATCH_SIZE; offset < recordsToFetch; offset += SAFE_BATCH_SIZE) {
+      const queryKey = generateQueryKey ? generateQueryKey({
+        CONCURRENT_REQUESTS,
+        BATCH_LIMIT,
+        SAFE_BATCH_SIZE,
+        batchParams,
+        endpoint,
+        offset,
+        paramsArray,
+        passedQueryOptions,
+      }) : getDefaultNSArray(offset);
+
+      const paramString = [...paramsArray, `offset=${offset}`]?.join('&');
+      queryArray.push({
+        queryKey,
+        queryFn: () => ky.get(`${endpoint}?${paramString}`).json(),
+        // Only enable once the previous slice has all been fetched
+        enabled: queryEnabled && offset / SAFE_BATCH_SIZE < CONCURRENT_REQUESTS,
+        ...queryOptions
+      });
+    }
+    return queryArray;
+  }, [
+    firstFetchResult,
+    BATCH_LIMIT,
+    SAFE_BATCH_SIZE,
+    generateQueryKey,
+    CONCURRENT_REQUESTS,
+    batchParams,
+    endpoint,
+    paramsArray,
+    passedQueryOptions,
+    getDefaultNSArray, queryEnabled, queryOptions, ky
+  ]);
+
+  // Differentiate between chunked logic and the first return (Which includes the initial fetch)
+  const itemQueries = useQueries(getQueryArray());
+  const returnItemQueries = useMemo(() => [firstFetchResult, ...itemQueries], [firstFetchResult, itemQueries]);
+
+  // Once chunk has finished fetching, fetch next chunk
+  useEffect(() => {
+    const chunkedQuery = chunk(returnItemQueries, CONCURRENT_REQUESTS);
+    chunkedQuery.forEach((q, i) => {
+      // Check that all previous chunk are fetched,
+      // and that all of our current chunk are not fetched and not loading
+      if (
+        i !== 0 &&
+        chunkedQuery[i - 1]?.every(pq => pq.isFetched === true) &&
+        q.every(req => req.isFetched === false) &&
+        q.every(req => req.isLoading === false)
+      ) {
+        // Trigger fetch for each request in the chunk
+        q.forEach(req => {
+          req.refetch();
+        });
+      }
+    });
+  }, [CONCURRENT_REQUESTS, returnItemQueries]);
+
+  // Keep easy track of whether this hook is all loaded or not
+  // (This slightly flattens the "isLoading/isFetched" distinction, but it's an ease of use prop)
+  useEffect(() => {
+    const newLoading = ((itemQueries?.length ?? 0) < 1 || itemQueries?.some(uq => !uq.isFetched));
+
+    if (isLoading !== newLoading) {
+      setIsLoading(newLoading);
+    }
+  }, [isLoading, itemQueries]);
+
+  return {
+    itemQueries: returnItemQueries,
+    isLoading,
+    // Offer all fetched orderLines in flattened array once ready
+    items: isLoading ? [] : returnItemQueries?.reduce((acc, curr) => {
+      return [...acc, ...(curr?.data?.results ?? [])];
+    }, []),
+  };
+};
+
+export default useParallelBatchFetch;


### PR DESCRIPTION
Created new hook "useParallelBatchFetch" which brings batch fetching from KIWT endpoints in line with useChunkedCQLFetch, in that multiple fetches happen in parallel, speeding the process up significantly.

Also tweaks to useChunkedCQLFetch to bring it in line with PR in stripes core