### PR TITLE
ERM-2973: Replace naive fetch hooks with parallelised ones (and deprecate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 * Added useParallelBatchFetch hook
   * For batch fetching KIWT resources
   * API more in line with useChunkedCQLFetch -- and in parallel
+* ERM-2973 Replace naive fetch hooks with parallelised ones (and deprecate)
+  * ERM-2974 DEPRECATED useBatchedFetch
+  * ERM-2975 DEPRECATED useUsers
+  * ERM-2976 InternalContactsSelection now uses useParallelBatchFetch
 
 ## 8.0.0 2023-02-22
 * ERM-2634 If an agreement or license has >10 contacts they do not all display correctly

--- a/lib/InternalContactSelection/InternalContactSelection.js
+++ b/lib/InternalContactSelection/InternalContactSelection.js
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import uniqBy from 'lodash/uniqBy';
 
-import { useBatchedFetch, useChunkedUsers } from '../hooks';
+import { useChunkedUsers, useParallelBatchFetch } from '../hooks';
 import renderUserName from '../renderUserName';
 import InternalContactSelectionDisplay from './InternalContactSelectionDisplay';
 
@@ -14,14 +14,14 @@ const InternalContactSelection = ({
 }) => {
   // Batch fetch all contacts from path handed to us
   const {
-    results: contacts,
+    items: contacts,
     isLoading: areContactsLoading
-  } = useBatchedFetch({
+  } = useParallelBatchFetch({
     // Ensure we get a uniquely ordered list
     batchParams: {
       sort: [{ path: 'id' }]
     },
-    path
+    endpoint:path
   });
 
   const contactsUserIds = useMemo(() => uniqBy(contacts, 'user')?.filter(c => c.user)?.map(c => c.user) ?? [], [contacts]);

--- a/lib/hooks/useBatchedFetch.js
+++ b/lib/hooks/useBatchedFetch.js
@@ -1,3 +1,5 @@
+/* DEPRECATED */
+
 import { useEffect, useMemo } from 'react';
 import { useOkapiKy } from '@folio/stripes/core';
 import { generateKiwtQueryParams } from '@k-int/stripes-kint-components';
@@ -14,6 +16,9 @@ const useBatchedFetch = ({
   path,
   queryParams
 }) => {
+  /* eslint-disable no-console */
+  console.warn(`Warning: useBatchedFetch is deprecated in stripes-erm-components and will be removed in a future release.
+  Switch to using useParallelBatchFetch instead.`);
   const ky = useOkapiKy();
   const safeBatchSize = Math.min(batchSize, MAX_BATCH_SIZE);
 

--- a/lib/hooks/useParallelBatchFetch.js
+++ b/lib/hooks/useParallelBatchFetch.js
@@ -62,6 +62,8 @@ const useParallelBatchFetch = ({
     passedQueryOptions
   );
 
+  const totalRecords = useMemo(() => firstFetchResult?.data?.total ?? 0, [firstFetchResult]);
+
   // WAIT for initial fetch to conclude before setting up queryArray
   // Set up query array, and only enable the first CONCURRENT_REQUESTS requests
   const getQueryArray = useCallback(() => {
@@ -69,7 +71,6 @@ const useParallelBatchFetch = ({
       return [];
     }
 
-    const totalRecords = firstFetchResult?.data?.total ?? 0;
     const recordsToFetch = Math.min(totalRecords, BATCH_LIMIT);
     // Have already fetched page 1
 
@@ -98,16 +99,20 @@ const useParallelBatchFetch = ({
     }
     return queryArray;
   }, [
-    firstFetchResult,
     BATCH_LIMIT,
-    SAFE_BATCH_SIZE,
-    generateQueryKey,
-    CONCURRENT_REQUESTS,
     batchParams,
+    CONCURRENT_REQUESTS,
     endpoint,
+    firstFetchResult,
+    generateQueryKey,
+    getDefaultNSArray,
+    ky,
     paramsArray,
     passedQueryOptions,
-    getDefaultNSArray, queryEnabled, queryOptions, ky
+    queryEnabled,
+    queryOptions,
+    SAFE_BATCH_SIZE,
+    totalRecords
   ]);
 
   // Differentiate between chunked logic and the first return (Which includes the initial fetch)
@@ -151,6 +156,7 @@ const useParallelBatchFetch = ({
     items: isLoading ? [] : returnItemQueries?.reduce((acc, curr) => {
       return [...acc, ...(curr?.data?.results ?? [])];
     }, []),
+    total: totalRecords
   };
 };
 

--- a/lib/hooks/useUsers.js
+++ b/lib/hooks/useUsers.js
@@ -1,8 +1,12 @@
+/* DEPRECATED */
 import { useQuery } from 'react-query';
 
 import { useOkapiKy, useStripes } from '@folio/stripes/core';
 
 const useUsers = (userIds = [], queryParams = {}) => {
+  /* eslint-disable no-console */
+  console.warn(`Warning: useUsers is deprecated in stripes-erm-components and will be removed in a future release.
+  Switch to using useChunkedUsers instead.`);
   const stripes = useStripes();
   /* Behaviour needs to be refactored.
      The query variable is either a string or an empty array,


### PR DESCRIPTION
feat: Swap to useParallelBatchFetch

Swap InternalContactSelection over to use useParallelBatchFetch in place of useBatchedFetch for internal contacts fetch

Also pass total from useParallelBatchFetch

Deprecated useUsers and useBatchedFetch

refs ERM-2973, ERM-2974, ERM-2975, ERM-2976