### PR TITLE
fix: Parallel batch fetch single page never returns items

### DIFF
--- a/lib/hooks/useParallelBatchFetch.js
+++ b/lib/hooks/useParallelBatchFetch.js
@@ -142,12 +142,12 @@ const useParallelBatchFetch = ({
   // Keep easy track of whether this hook is all loaded or not
   // (This slightly flattens the "isLoading/isFetched" distinction, but it's an ease of use prop)
   useEffect(() => {
-    const newLoading = ((itemQueries?.length ?? 0) < 1 || itemQueries?.some(uq => !uq.isFetched));
+    const newLoading = ((returnItemQueries?.length ?? 0) < 1 || returnItemQueries?.some(uq => !uq.isFetched));
 
     if (isLoading !== newLoading) {
       setIsLoading(newLoading);
     }
-  }, [isLoading, itemQueries]);
+  }, [isLoading, returnItemQueries]);
 
   return {
     itemQueries: returnItemQueries,


### PR DESCRIPTION
Fixed bug where a parallel batch fetch which only needs a single page would remain in a "loading" state forever and hence not return the items

refs ERM-2973