### PR TITLE
ERM-2967: Use useChunkedCQLFetch consistently across ERM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * ERM-2976 InternalContactsSelection now uses useParallelBatchFetch
   * STRIPES-870 BREAKING upgrade react to v18
     * ERM-2989 Upgrade stripes-erm-components React to v18
+  * Deprecated useChunkedCQLFetch -- can import from stripes/core now
 
 ## 8.0.0 2023-02-22
 * ERM-2634 If an agreement or license has >10 contacts they do not all display correctly

--- a/lib/hooks/useChunkedCQLFetch.js
+++ b/lib/hooks/useChunkedCQLFetch.js
@@ -33,6 +33,11 @@ const useChunkedCQLFetch = ({
   reduceFunction, // Function to reduce fetched objects at the end into single array
   STEP_SIZE = STEP_SIZE_DEFAULT // Number of ids fetch per request
 }) => {
+  /* eslint-disable no-console */
+  console.warn(`Warning: useChunkedCQLFetch is deprecated in stripes-erm-components
+  and will be removed in a future release. This same hook can be imported from
+  @folio/stripes/core`);
+
   const ky = useOkapiKy();
 
   // Destructure passed query options to grab enabled

--- a/lib/hooks/useChunkedUsers.js
+++ b/lib/hooks/useChunkedUsers.js
@@ -1,4 +1,4 @@
-import useChunkedCQLFetch from './useChunkedCQLFetch';
+import { useChunkedCQLFetch } from '@folio/stripes/core';
 
 // When fetching from a potentially large list of users,
 // make sure to chunk the request to avoid hitting limits.


### PR DESCRIPTION
feat: Deprecate useChunkedCQLFetch

Deprecated useChunkedCQLFetch, and moved internal imports over to stripes-core implementation

ERM-2967