### PR TITLE
ERM-2937: usePrevNextPagination

### DIFF
--- a/lib/hooks/usePrevNextPagination.js
+++ b/lib/hooks/usePrevNextPagination.js
@@ -100,8 +100,7 @@ const usePrevNextPagination = ({
       'filter.clearGroup',
       'sort.change',
       'search.reset',
-      'search.submit',
-      'all.submit'
+      'search.submit'
     ];
 
     if (resetPageEvents.includes(nextState.changeType)) {


### PR DESCRIPTION
chore: Remove case

Remove submit.all case from page reset to avoid page reset on first load