### PR TITLE
ERM-3040 Dashboard: "New" badge is wrapping onto two lines

### DIFF
--- a/lib/NewBox/NewBox.js
+++ b/lib/NewBox/NewBox.js
@@ -3,6 +3,7 @@ import InfoBox from '../InfoBox';
 
 const NewBox = () => (
   <InfoBox
+    style={{ overflowX: 'hidden' }}
     type="success"
   >
     <FormattedMessage id="stripes-erm-components.new" />


### PR DESCRIPTION
* add overflowX: 'hidden' style to InfoBox in NewBox