### PR TITLE
ERM-3045: Swap Logs component to prev-next pagination (FIX -- page storage)

### DIFF
--- a/lib/Logs/Logs.js
+++ b/lib/Logs/Logs.js
@@ -32,6 +32,8 @@ const Logs = ({
   const { currentPage, paginationMCLProps } = usePrevNextPagination({
     count,
     pageSize: RESULT_COUNT_INCREMENT,
+    // With syncToLocation false, this needs a unique id, so error/info aren't on the same page
+    id: `${job.id}-${id}`,
     syncToLocation: false
   });
 

--- a/lib/constants/index.js
+++ b/lib/constants/index.js
@@ -1,3 +1,5 @@
 export * from './endpoints';
 export * from './errorTypes';
 export * from './pagination';
+
+export const DEFAULT_PAGE_KEY = 'defaultPageKey';

--- a/lib/hooks/useLocalPageStore.js
+++ b/lib/hooks/useLocalPageStore.js
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+import { DEFAULT_PAGE_KEY } from '../constants';
+
+// Any time that usePrevNextPagination is NOT synced to location,
+// store a keyed currentPage here instead
+const useLocalPageStore = create(
+  (set) => ({
+    pageStore: {},
+    setPage: (id, page) => set((state) => {
+      // Any non-id keyed pages will go into a single storage slot
+      const key = id ?? DEFAULT_PAGE_KEY;
+
+      return { ...state, pageStore: { ...state.pageStore, [key]: page } };
+    }),
+  }),
+);
+
+export default useLocalPageStore;

--- a/lib/hooks/usePrevNextPagination.js
+++ b/lib/hooks/usePrevNextPagination.js
@@ -4,21 +4,51 @@ import { useLocation, useHistory } from 'react-router-dom';
 import queryString from 'query-string';
 import {
   DEFAULT_PAGINATION_SIZE,
+  DEFAULT_PAGE_KEY,
   MCL_NEED_MORE_DATA_PREV_NEXT_ARG_INDEX,
   NEXT,
   PREV
 } from '../constants';
 
+import useLocalPageStore from './useLocalPageStore';
+
 const usePrevNextPagination = ({
   count = 0, // Only needed for reading back MCL props
   defaultToPageOne = true, // A prop to allow the implementor to turn off the defaulting to page=1
   pageSize = DEFAULT_PAGINATION_SIZE, // Only needed for reading back MCL props
+  id = DEFAULT_PAGE_KEY, // This id is ONLY used for syncToLocation: false cases, as a key to the zustand store
   syncToLocation = true // Used to turn on/off location syncing, so can be used as standalone state if required
 } = {}) => {
-  const [currentPage, setCurrentPage] = useState(syncToLocation ? undefined : 1);
+  /* ------ ZUSTAND STORE ------ */
+  // For NON-SYNC-TO-LOCATION use cases, store the currentPage in a keyed store
+  const pageStore = useLocalPageStore(state => state.pageStore);
+  const setPage = useLocalPageStore(state => state.setPage);
+
+  /* ------ CURRENTPAGE STATE ------ */
+  // Set up initialValue
+  const getInitialCurrentPage = useCallback(() => {
+    let initialCurrentPage;
+    if (!syncToLocation) {
+      if (pageStore[id]) {
+        initialCurrentPage = pageStore[id];
+      } else {
+        // Initialise store state
+        setPage(id, 1);
+        initialCurrentPage = 1;
+      }
+    }
+
+    return initialCurrentPage;
+  }, [id, pageStore, setPage, syncToLocation]);
+  // State itself
+  const [currentPage, setCurrentPage] = useState(getInitialCurrentPage());
+
   const location = useLocation();
   const history = useHistory();
 
+  /* ------ HANDLEPAGECHANGE ------ */
+  // Takes in a direction "prev" or "next" and performs the requisite logic to move
+  // currentPage state and/or zustand store state
   const handlePageChange = useCallback((direction) => {
     const urlQuery = queryString.parse(location.search);
 
@@ -31,6 +61,9 @@ const usePrevNextPagination = ({
 
     if (!syncToLocation) {
       // We're manipulating the state directly in this case
+      // We're dealing with the zustand store in this case,
+      // change the store and the currentPage will update below
+      setPage(id, newPage);
       setCurrentPage(newPage);
     } else if (newPage !== urlQuery?.page) {
       const newQuery = {
@@ -42,13 +75,27 @@ const usePrevNextPagination = ({
         search: `?${queryString.stringify(newQuery)}`
       });
     }
-  }, [currentPage, history, location.pathname, location.search, syncToLocation]);
+  }, [
+    currentPage,
+    history,
+    id,
+    location.pathname,
+    location.search,
+    setPage,
+    syncToLocation
+  ]);
+
+
 
   const [resetPageState, setResetPageState] = useState(false);
-
   const resetPage = useCallback(() => {
-    setResetPageState(true);
-  }, []);
+    if (syncToLocation) {
+      setResetPageState(true);
+    } else {
+      setPage(id, 1);
+      setCurrentPage(1);
+    }
+  }, [id, setPage, syncToLocation]);
 
   useEffect(() => {
     if (syncToLocation) {
@@ -82,12 +129,18 @@ const usePrevNextPagination = ({
         });
         setResetPageState(false);
       }
+    } else if (currentPage !== pageStore[id]) {
+      // Only do this when not syncing to location...
+      // If current page state is not what we have in the store, set current page state
+      setCurrentPage(pageStore[id]);
     }
   }, [
     currentPage,
     defaultToPageOne,
     history,
+    id,
     location,
+    pageStore,
     resetPageState,
     syncToLocation
   ]);

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "regenerator-runtime": "^0.13.3",
     "rxjs": "^6.6.3",
     "testing-library-selector": "^0.2.1",
-    "typescript": "^2.8.0"
+    "typescript": "^2.8.0",
+    "zustand": "^4.4.0"
   },
   "dependencies": {
     "@k-int/stripes-kint-components": "^5.0.0",
@@ -61,7 +62,8 @@
     "react-intl": "^6.4.4",
     "react-query": "^3.9.0",
     "react-redux": "^8.0.5",
-    "react-router-dom": "^5.2.0"
+    "react-router-dom": "^5.2.0",
+    "zustand": "^4.4.0"
   },
   "stripes": {
     "actsAs": [


### PR DESCRIPTION
feat: usePrevNextPagination pageStore

Added pageStore, so that each implementation of usePrevNextPagination with syncToLocation: false can have their own currentPage state, which persists between redraws (but NOT refreshes)