### PR TITLE
fix: usePrevNextPagination null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-erm-components
 
 ## 9.1.0 In progress
+* usePrevNextPagination null safety (yarn test warnings)
 
 ## 9.0.0 2023-10-12
 * Added useParallelBatchFetch hook

--- a/lib/hooks/usePrevNextPagination.js
+++ b/lib/hooks/usePrevNextPagination.js
@@ -148,7 +148,7 @@ const usePrevNextPagination = ({
   // Set up MCL specific props based on page
   const pagingCanGoNext = currentPage && currentPage < Number(count) / pageSize;
   const pagingCanGoPrevious = currentPage && Number(currentPage) > 1;
-  const pagingOffset = (currentPage - 1) * pageSize;
+  const pagingOffset = currentPage ? (currentPage - 1) * pageSize : 0;
   const onNeedMoreData = (...args) => {
     if (args[MCL_NEED_MORE_DATA_PREV_NEXT_ARG_INDEX]) {
       handlePageChange(args[MCL_NEED_MORE_DATA_PREV_NEXT_ARG_INDEX]);


### PR DESCRIPTION
Occasionally usePrevNextPagination would attempt a numeric operation on an undefined variable `currentPage`. This is now protected against.