### PR TITLE
ERM-3186: Change default search options for Local KB titles to exclude identifiers (defaultSearchKey)

### DIFF
--- a/lib/hooks/useSASQQIndex.js
+++ b/lib/hooks/useSASQQIndex.js
@@ -6,7 +6,19 @@ import { useQIndex } from '@k-int/stripes-kint-components';
 // the props etc needed to utilise that within SASQ (and generateKiwtQueryParams)
 const useSASQQIndex = ({
   defaultQIndex = '',
-  defaultQuery = '' // This is mainly here so we can avoid extra boilerplate fiddling if we want a default query at some point
+  /*
+   * defaultQuery is mainly here so we can avoid extra boilerplate fiddling
+   * if we want a default query at some point
+   */
+  defaultQuery = '',
+  /*
+   * In some circumstances you may wish the searchKey to _not_ be
+   * equivalent to the defaultQIndex when no qIndex exists in the url,
+   * such as when the defaultQindex is a subset of the options available
+   * to the user in a SearchKeyControl. In that case deselecting all options
+   * is assumed to be equivalent to selecting all options.
+   */
+  defaultSearchKey = '',
 } = {}) => {
   const [qIndex, setQIndex] = useQIndex();
 
@@ -38,8 +50,12 @@ const useSASQQIndex = ({
       return qIndex;
     }
 
+    if (!!defaultSearchKey && defaultSearchKey !== '') {
+      return defaultSearchKey;
+    }
+
     return defaultQIndex;
-  }, [defaultQIndex, qIndex]);
+  }, [defaultQIndex, defaultSearchKey, qIndex]);
 
   return {
     initialSearchState,


### PR DESCRIPTION
feat: useSASQQIndex defaultSearchKey

Add a defaultSearchKey prop to useSASQQIndex which allows the implementor to separate out the default behaviour of qIndex passed to SASQ and the default searchKey used for the backend query, since these occasionally need to differ.

This is not necessary for ERM-3186 directly, but provides an option for use cases where this all happens in a single `useSASQQIndex` call instead of two split between Route and View.

refs ERM-3186